### PR TITLE
removed link to homepage from logo

### DIFF
--- a/_sass/components/_top-nav-bar-styling.scss
+++ b/_sass/components/_top-nav-bar-styling.scss
@@ -3,6 +3,11 @@
     color: $dark;
 }
 
+.navbar-brand {
+  pointer-events: none;
+  cursor: default;
+}
+
 //GitHub icon color in the top right corner
 .me-2{
     color: $top-nav-icon;


### PR DESCRIPTION
The logo on the top navigation bar is now not clickable.

Closes #173 