### PR TITLE
Add initial guidance page metadata elements

### DIFF
--- a/_data/glossary/glossary.json
+++ b/_data/glossary/glossary.json
@@ -859,17 +859,6 @@
     ]
   },
   {
-    "term": "Keywords",
-    "definition": "Word that deals with a topic in a text and that are used for topic development and topic searches.",
-    "sources": [
-      {
-        "label": "Wikidata",
-        "url": "https://www.wikidata.org/wiki/Q12310022"
-      }
-    ],
-    "aliases": []
-  },
-  {
     "term": "knowledge management",
     "definition": "Process of creating, sharing, using and managing the knowledge and information of an organization.",
     "sources": [

--- a/_data/glossary/glossary.json
+++ b/_data/glossary/glossary.json
@@ -144,6 +144,12 @@
     "aliases": []
   },
   {
+    "term": "Citizen",
+    "definition": "Individual participating in or contributing to research activities, typically outside a formal professional role.",
+    "sources": [],
+    "aliases": []
+  },
+  {
     "term": "Clinical data",
     "definition": "Clinical data is data that has to do with the health or treatment of people. They may come from clinical research, where treatments or other medical interventions are tested on human subjects, or from clinical practice, where Healthcare Professionals or patients collect data about their patients or in the case patients themselves.",
     "sources": [
@@ -313,6 +319,12 @@
     ]
   },
   {
+    "term": "Data collection specialist",
+    "definition": "Collects and records data in operational or clinical settings, ensuring accuracy and usability, often through direct interaction with participants or patients.",
+    "sources": [],
+    "aliases": []
+  },
+  {
     "term": "Data curation",
     "definition": "Managed process throughout the data lifecycle, by which data/data collections are cleansed, documented, standardised, formatted and inter-related. The goal of curation is to manage and promote the use of data from its point of creation to ensure it is fit for contemporary purpose and available for discovery and re-use. For dynamic datasets this may mean continuous enrichment or updating to keep it fit for purpose. Special forms of curation may be available in data repositories. The data curation process itself must be documented as part of curation. Thus curation and provenance are highly related.",
     "sources": [
@@ -426,6 +438,12 @@
         "url": "https://terms.codata.org/rdmt/re-use"
       }
     ],
+    "aliases": []
+  },
+  {
+    "term": "Data scientist",
+    "definition": "Analyses data using statistical and computational methods to generate models, insights and interpretations.",
+    "sources": [],
     "aliases": []
   },
   {
@@ -616,6 +634,12 @@
       "EHR",
       "Electronic Health Record (EHR)"
     ]
+  },
+  {
+    "term": "ELSI expert",
+    "definition": "Advises on ethical, legal and societal implications of data use and research practices.",
+    "sources": [],
+    "aliases": []
   },
   {
     "term": "European Commision Joint Research Centre",
@@ -832,6 +856,12 @@
       "ICF",
       "Informed Consent Form (ICF)"
     ]
+  },
+  {
+    "term": "Infrastructure professional",
+    "definition": "Manages and maintains computing infrastructure, including systems, storage, networking and deployment environments.",
+    "sources": [],
+    "aliases": []
   },
   {
     "term": "Interoperable",
@@ -1199,6 +1229,18 @@
     ]
   },
   {
+    "term": "Policy specialist",
+    "definition": "Develops, interprets and applies policies and frameworks to guide data management, sharing and FAIR practices.",
+    "sources": [],
+    "aliases": []
+  },
+  {
+    "term": "Project manager",
+    "definition": "Coordinates planning, resources, stakeholders and delivery to ensure project objectives are met.",
+    "sources": [],
+    "aliases": []
+  },
+  {
     "term": "Pseudonymous data",
     "definition": "‘pseudonymisation’ means the processing of personal data in such a manner that the personal data can no longer be attributed to a specific data subject without the use of additional information, provided that such additional information is kept separately and is subject to technical and organisational measures to ensure that the personal data are not attributed to an identified or identifiable natural person.",
     "sources": [
@@ -1279,6 +1321,12 @@
     "aliases": []
   },
   {
+    "term": "Researcher",
+    "definition": "Provides domain expertise, formulates research questions and interprets findings within a scientific context.",
+    "sources": [],
+    "aliases": []
+  },
+  {
     "term": "Resource Description Framework",
     "definition": "RDF is a standard model for data interchange on the Web. RDF has features that facilitate data merging even if the underlying schemas differ, and it specifically supports the evolution of schemas over time without requiring all the data consumers to be changed. RDF extends the linking structure of the Web to use URIs to name the relationship between things as well as the two ends of the link (this is usually referred to as a “triple”). Using this simple model, it allows structured and semi-structured data to be mixed, exposed, and shared across different applications.",
     "sources": [
@@ -1356,6 +1404,12 @@
         "url": "https://www.bath.ac.uk/guides/working-with-secondary-data"
       }
     ],
+    "aliases": []
+  },
+  {
+    "term": "Semantic expert",
+    "definition": "Designs and applies metadata models, ontologies and vocabularies to ensure interoperability and machine readability.",
+    "sources": [],
     "aliases": []
   },
   {
@@ -1466,6 +1520,18 @@
       "SIS",
       "Subject Information Sheet (SIS)"
     ]
+  },
+  {
+    "term": "Technical specialist",
+    "definition": "Implements and integrates specific technical solutions such as identifiers, APIs or system components within a broader infrastructure.",
+    "sources": [],
+    "aliases": []
+  },
+  {
+    "term": "Trainer",
+    "definition": "Designs and delivers training and capacity building to support effective data and tool use.",
+    "sources": [],
+    "aliases": []
   },
   {
     "term": "Trusted repository",

--- a/_data/metroline_steps.yml
+++ b/_data/metroline_steps.yml
@@ -4,6 +4,18 @@
   url: metroline_steps/define_fairification_objectives
   icon: ":dart:"
   status: RELEASED
+  keywords:
+    - planning
+    - goals
+    - governance
+  core_roles:
+    - Data steward
+    - ELSI expert
+    - Researcher
+    - Semantic expert
+  audience:
+    data_holder: true
+    data_user: true
 - id: 2
   title: Build the Team
   summary: Coming soon.

--- a/_data/metroline_steps.yml
+++ b/_data/metroline_steps.yml
@@ -9,10 +9,10 @@
     - goals
     - governance
   expertise_required:
-    - Data steward
+    - data steward
     - ELSI expert
-    - Researcher
-    - Semantic expert
+    - researcher
+    - semantic expert
   audience:
     data_holder: true
     data_user: true
@@ -33,10 +33,10 @@
     - support
     - governance
   expertise_required:
-    - Data steward
-    - Infrastructure professional
-    - Project manager
-    - Researcher
+    - data steward
+    - infrastructure professional
+    - project manager
+    - researcher
   audience:
     data_holder: true
     data_user: true
@@ -50,8 +50,8 @@
     - training
     - skills
   expertise_required:
-    - Data steward
-    - Researcher
+    - data steward
+    - researcher
     - Trainer
   audience:
     data_holder: true
@@ -66,8 +66,8 @@
     - assessment
     - FAIR maturity
   expertise_required:
-    - Data steward
-    - Research software engineer
+    - data steward
+    - research software engineer
   audience:
     data_holder: true
     data_user: true
@@ -81,10 +81,10 @@
     - planning
     - implementation
   expertise_required:
-    - Data steward
-    - Infrastructure professional
-    - Project manager
-    - Researcher
+    - data steward
+    - infrastructure professional
+    - project manager
+    - researcher
   audience:
     data_holder: true
     data_user: true
@@ -98,10 +98,10 @@
     - data access
     - data retrieval
   expertise_required:
-    - Data steward
+    - data steward
     - ELSI expert
-    - Infrastructure professional
-    - Researcher
+    - infrastructure professional
+    - researcher
   audience:
     data_holder: false
     data_user: true
@@ -116,8 +116,8 @@
     - availability
     - discovery
   expertise_required:
-    - Data steward
-    - Researcher
+    - data steward
+    - researcher
   audience:
     data_holder: true
     data_user: true
@@ -131,8 +131,8 @@
     - identifiers
     - persistence
   expertise_required:
-    - Policy specialist
-    - Technical specialist
+    - policy specialist
+    - technical specialist
   audience:
     data_holder: true
     data_user: true
@@ -147,9 +147,9 @@
     - publication
     - discovery
   expertise_required:
-    - Data steward
-    - Infrastructure professional
-    - Researcher
+    - data steward
+    - infrastructure professional
+    - researcher
   audience:
     data_holder: true
     data_user: false
@@ -164,8 +164,8 @@
     - metadata
     - publication
   expertise_required:
-    - Data steward
-    - Researcher
+    - data steward
+    - researcher
   audience:
     data_holder: true
     data_user: false
@@ -180,8 +180,8 @@
     - standardisation
     - CDE
   expertise_required:
-    - Data steward
-    - Researcher
+    - data steward
+    - researcher
   audience:
     data_holder: true
     data_user: true
@@ -195,9 +195,9 @@
     - codebook
     - semantics
   expertise_required:
-    - Data steward
-    - Researcher
-    - Semantic expert
+    - data steward
+    - researcher
+    - semantic expert
   audience:
     data_holder: true
     data_user: true
@@ -213,9 +213,9 @@
     - data collection
     - codebook
   expertise_required:
-    - Data collection specialist
-    - Data steward
-    - Researcher
+    - data collection specialist
+    - data steward
+    - researcher
   audience:
     data_holder: true
     data_user: false
@@ -229,13 +229,13 @@
     - semantic model
     - semantics
   expertise_required:
-    - Semantic expert
+    - semantic expert
   audience:
     data_holder: true
     data_user: true
 - id: 16
   title: Use ontologies in the model
-  summary: This process involves linking your semantic (meta)data model to ontologies, which are formal, shared vocabularies that provide precise, machine-readable definitions for concepts. This step is written for a broad FAIRification audience and may be used by researchers, data stewards, metadata specialists and ontology or semantic web technology experts, depending on the project context. Not all activities need to be carried out by the same person. Researchers and project teams can use this step to understand the process and provide domain knowledge, while specialist support may be needed for ontology selection, concept mapping, formal representation, validation and maintenance. By assigning standard definitions to the elements in your model, you make their meanings explicit and unambiguous. This allows different computer systems to correctly understand, combine and compare data from various sources consistently, making the data more interoperable and easier to reuse across projects.
+  summary: This process involves linking your semantic (meta)data model to ontologies, which are formal, shared vocabularies that provide precise, machine-readable definitions for concepts. This step is written for a broad FAIRification audience and may be used by researchers, data stewards, metadata specialists and ontology or semantic web technology experts, depending on the project context. Not all activities need to be carried out by the same person. researchers and project teams can use this step to understand the process and provide domain knowledge, while specialist support may be needed for ontology selection, concept mapping, formal representation, validation and maintenance. By assigning standard definitions to the elements in your model, you make their meanings explicit and unambiguous. This allows different computer systems to correctly understand, combine and compare data from various sources consistently, making the data more interoperable and easier to reuse across projects.
   url: metroline_steps/use_ontologies_in_the_model
   icon: ":book:"
   status: RELEASED
@@ -244,7 +244,7 @@
     - ontologies
     - semantics
   expertise_required:
-    - Semantic expert
+    - semantic expert
   audience:
     data_holder: true
     data_user: true
@@ -280,10 +280,10 @@
     - tools
     - semantic model
   expertise_required:
-    - Data steward
-    - Researcher
-    - Semantic expert
-    - Technical specialist
+    - data steward
+    - researcher
+    - semantic expert
+    - technical specialist
   audience:
     data_holder: true
     data_user: false
@@ -298,10 +298,10 @@
     - RDF
     - publication
   expertise_required:
-    - Data steward
-    - Infrastructure professional
-    - Researcher
-    - Semantic expert
+    - data steward
+    - infrastructure professional
+    - researcher
+    - semantic expert
   audience:
     data_holder: true
     data_user: false
@@ -317,9 +317,9 @@
     - governance
   expertise_required:
     - Data curator
-    - Data steward
+    - data steward
     - ELSI expert
-    - Researcher
+    - researcher
   audience:
     data_holder: true
     data_user: false
@@ -332,9 +332,9 @@
   keywords:
     - querying
   expertise_required:
-    - Data scientist
-    - Researcher
-    - Semantic expert
+    - data scientist
+    - researcher
+    - semantic expert
   audience:
     data_holder: false
     data_user: true
@@ -348,9 +348,9 @@
     - assessment
     - FAIR maturity
   expertise_required:
-    - Data steward
-    - Research software engineer
-    - Researcher
+    - data steward
+    - research software engineer
+    - researcher
   audience:
     data_holder: true
     data_user: true
@@ -372,8 +372,8 @@
     - governance
   expertise_required:
     - ELSI expert
-    - Researcher
-    - Semantic expert
+    - researcher
+    - semantic expert
   audience:
     data_holder: true
     data_user: true

--- a/_data/metroline_steps.yml
+++ b/_data/metroline_steps.yml
@@ -8,7 +8,7 @@
     - planning
     - goals
     - governance
-  core_roles:
+  expertise_required:
     - Data steward
     - ELSI expert
     - Researcher
@@ -28,66 +28,179 @@
   url: metroline_steps/have_a_fair_data_steward_on_board
   icon: ":mechanic:"
   status: RELEASED
+  keywords:
+    - expertise
+    - support
+    - governance
+  expertise_required:
+    - Data steward
+    - Infrastructure professional
+    - Project manager
+    - Researcher
+  audience:
+    data_holder: true
+    data_user: true
 - id: 4
   title: Organise Training
   summary: This page brings forward the training and educational elements available to guide the team in their journey through the Metroline subsequent steps.
   url: metroline_steps/organise_training
   icon: ":weight_lifting:"
   status: READY FOR REVIEW
+  keywords:
+    - training
+    - skills
+  expertise_required:
+    - Data steward
+    - Researcher
+    - Trainer
+  audience:
+    data_holder: true
+    data_user: true
 - id: 5
   title: Pre-FAIR assessment
   summary: A pre-FAIR assessment evaluates the current state of your data and its alignment with the FAIR principles. Performing this assessment early makes you aware of possibilities for increasing the FAIRness of your data, which in turn increases its impact and ensures its long-term usability.
   url: metroline_steps/pre_fair_assessment
   icon: ":white_check_mark:"
   status: RELEASED
+  keywords:
+    - assessment
+    - FAIR maturity
+  expertise_required:
+    - Data steward
+    - Research software engineer
+  audience:
+    data_holder: true
+    data_user: true
 - id: 6
   title: Design Solution Plan
   summary: This step is about turning the findings from the pre-FAIR assessment into a clear, actionable plan. It means choosing the right tools, deciding who does what, and making sure the process is simple and effective so data can actually become FAIR.
   url: metroline_steps/design_solution_plan
   icon: ":bookmark_tabs:"
   status: RELEASED
+  keywords:
+    - planning
+    - implementation
+  expertise_required:
+    - Data steward
+    - Infrastructure professional
+    - Project manager
+    - Researcher
+  audience:
+    data_holder: true
+    data_user: true
 - id: 7
   title: Data access and retrieval
   summary: Before data can be made FAIR, we first need to get it the right way. That means finding trustworthy sources, making sure we’re allowed to use the data, and keeping it safe and private. When we do this properly, it ensures that the data can be trusted, shared, and reused to support new research and innovation.
   url: metroline_steps/data_access_and_retrieval
   icon: ":closed_lock_with_key:"
   status: RELEASED
+  keywords:
+    - data access
+    - data retrieval
+  expertise_required:
+    - Data steward
+    - ELSI expert
+    - Infrastructure professional
+    - Researcher
+  audience:
+    data_holder: false
+    data_user: true
 - id: 8
   title: Assess availability of your metadata
   summary: Metadata describes a resource, like a book’s title and author or a photo’s date and location, which help with organization and discovery of that resource. This Metroline step describes the types of metadata, where you can find them for your resource, and how to improve their quality. Filling metadata gaps enhances a resource’s visibility and reusability.
   url: metroline_steps/assess_availability_of_your_metadata
   icon: ":books:"
   status: RELEASED
+  keywords:
+    - metadata
+    - availability
+    - discovery
+  expertise_required:
+    - Data steward
+    - Researcher
+  audience:
+    data_holder: true
+    data_user: true
 - id: 9
   title: Select Identifier Scheme
   summary: Coming soon.
   url: 
   icon: ":passport_control:"
   status: IN DEVELOPMENT
+  keywords:
+    - identifiers
+    - persistence
+  expertise_required:
+    - Policy specialist
+    - Technical specialist
+  audience:
+    data_holder: true
+    data_user: true
 - id: 10
   title: Register resource level metadata
   summary: To make your resource (e.g. data), available for reuse, its metadata can be published in a catalogue. This step helps you find a catalogue where you can register these resource metadata and explains why adding your resource to such a catalogue is important.
   url: metroline_steps/register_resource_level_metadata
   icon: ":card_file_box:"
   status: RELEASED
+  keywords:
+    - metadata
+    - publication
+    - discovery
+  expertise_required:
+    - Data steward
+    - Infrastructure professional
+    - Researcher
+  audience:
+    data_holder: true
+    data_user: false
 - id: 11
   title: Register structural metadata
   summary: This step focuses on how to share your resource’s structural metadata - an explanation of what each piece of your data means and how it’s organised. Publishing it helps others understand, find and reuse your data more easily. This step also shows how to make the metadata readable by computers, which can support specific FAIR objectives you may already have.
   url: metroline_steps/register_structural_metadata
   icon: ":card_file_box:"
   status: RELEASED
+  keywords:
+    - codebook
+    - metadata
+    - publication
+  expertise_required:
+    - Data steward
+    - Researcher
+  audience:
+    data_holder: true
+    data_user: false
 - id: 12
   title: Apply common data elements
   summary: Common data elements (CDEs) are standardised data elements, such as variables and measurements, paired with defined rules for how values should be recorded. They are developed to promote consistency and reuse in data collection across different settings, enabling seamless integration and comparison. This step encourages you to search for relevant CDEs and offers guidance on what to do if no suitable CDE is available.
   url: metroline_steps/apply_common_data_elements
   icon: ":toolbox:"
   status: RELEASED
+  keywords:
+    - codebook
+    - standardisation
+    - CDE
+  expertise_required:
+    - Data steward
+    - Researcher
+  audience:
+    data_holder: true
+    data_user: true
 - id: 13
   title: Analyse data semantics
   summary: In this step, the aim is to gain more insight into the existing data, or the data that you aim to collect. Clearly defining the meaning (semantics) of the data is an important step for creating the semantic model, as well as for data collection via, for example, electronic case report forms (eCRFs).
   url: metroline_steps/analyse_data_semantics
   icon: ":mag_right:"
   status: RELEASED
+  keywords:
+    - codebook
+    - semantics
+  expertise_required:
+    - Data steward
+    - Researcher
+    - Semantic expert
+  audience:
+    data_holder: true
+    data_user: true
 - id: 14
   title: Design eCRF (data collection)
   summary: >
@@ -95,24 +208,61 @@
   url: metroline_steps/design_ecrf
   icon: ":pencil:"
   status: RELEASED
+  keywords:
+    - eCRF
+    - data collection
+    - codebook
+  expertise_required:
+    - Data collection specialist
+    - Data steward
+    - Researcher
+  audience:
+    data_holder: true
+    data_user: false
 - id: 15
   title: Create or reuse a semantic (meta)data model
   summary: Creating a semantic (meta)data model often requires considerable effort as it is a complex task. Reusing an existing model, where possible, can save time and increase interoperability. Start by checking if a suitable model already exists. If not, follow a structured approach to create one. Once the model is in place, share it using common platforms and provide clear documentation to support reuse by others.
   url: metroline_steps/create_or_reuse_a_semantic_model
   icon: ":construction:"
   status: RELEASED
+  keywords:
+    - semantic model
+    - semantics
+  expertise_required:
+    - Semantic expert
+  audience:
+    data_holder: true
+    data_user: true
 - id: 16
   title: Use ontologies in the model
   summary: This process involves linking your data model to ontologies, which are essentially formal, shared dictionaries that provide precise, computer-readable definitions for concepts. By assigning these standard definitions to the elements in your data model, you make their meanings explicit and clear. This allows different computer systems to correctly understand, combine, and compare data from various sources without confusion, making the data more interoperable and easier to reuse across different projects.
   url: metroline_steps/use_ontologies_in_the_model
   icon: ":book:"
   status: READY FOR REVIEW
+  keywords:
+    - semantic model
+    - ontologies
+    - semantics
+  expertise_required:
+    - Semantic expert
+  audience:
+    data_holder: true
+    data_user: true
 - id: 17
   title: Obtain informed consent
   summary: To ensure your data and materials can be reused in the future, your subject information sheet (SIS) and informed consent form (ICF) must address reuse. This Metroline step provides consideration and resources for preparing your SIS and ICF.
   url: metroline_steps/obtain_informed_consent
   icon: ":person_red_hair:"
   status: RELEASED
+  keywords:
+    - consent
+    - data sharing
+    - legal
+  expertise_required:
+    - ELSI expert
+  audience:
+    data_holder: true
+    data_user: false
 - id: 18
   title: Enter data in eCRF (data collection)
   summary: On hold.
@@ -125,30 +275,85 @@
   url: metroline_steps/apply_metadata_model
   icon: ":card_file_box:"
   status: RELEASED
+  keywords:
+    - data transformation
+    - tools
+    - semantic model
+  expertise_required:
+    - Data steward
+    - Researcher
+    - Semantic expert
+    - Technical specialist
+  audience:
+    data_holder: true
+    data_user: false
 - id: 20
   title: Transform and expose FAIR (meta)data
   summary: Think of your data like a well-written book that’s hidden away on a shelf that no one knows about. By transforming it into a standardised, machine-readable format and publishing it through trusted channels, you place it in a public library where everyone, people and machines, can easily find, open, and read it.
   url: metroline_steps/transform_and_expose_fair_metadata
   icon: ":toolbox:"
   status: RELEASED
+  keywords:
+    - data transformation
+    - RDF
+    - publication
+  expertise_required:
+    - Data steward
+    - Infrastructure professional
+    - Researcher
+    - Semantic expert
+  audience:
+    data_holder: true
+    data_user: false
 - id: 21
   title: Define access conditions
   summary: When making health care data FAIR, data holders have to keep the balance between making data accessible for reuse and protecting personal information of subjects present in the data. This Metroline step helps you pick the appropriate access level to your data and publish the necessary information in the metadata.
   url: metroline_steps/define_access_conditions
   icon: ":closed_lock_with_key:"
   status: RELEASED
+  keywords:
+    - data sharing
+    - legal
+    - governance
+  expertise_required:
+    - Data curator
+    - Data steward
+    - ELSI expert
+    - Researcher
+  audience:
+    data_holder: true
+    data_user: false
 - id: 22
   title: Query (use) over resources
   summary: Querying FAIR resources is the process of asking structured questions to retrieve data that is easy to find, access, and reuse. When resources follow FAIR principles, queries become more efficient because the data is well-organized and clearly described. In this step, we will explore the tools and platforms that enable effective querying of FAIR-compliant resources.
   url: metroline_steps/query_over_resources
   icon: ":question:"
   status: RELEASED
+  keywords:
+    - querying
+  expertise_required:
+    - Data scientist
+    - Researcher
+    - Semantic expert
+  audience:
+    data_holder: false
+    data_user: true
 - id: 23
   title: Assess FAIRness
   summary: Now that you’ve FAIRified your data, it’s time to check the resulting FAIRness and decide if you’ve reached your goals. Use tools and other methods to assess if your data is truly Findable, Accessible, Interoperable, and Reusable. If needed, adjust or improve things so your data stays FAIR in the long run.
   url: metroline_steps/assess_fairness
   icon: ":white_check_mark:"
   status: RELEASED
+  keywords:
+    - assessment
+    - FAIR maturity
+  expertise_required:
+    - Data steward
+    - Research software engineer
+    - Researcher
+  audience:
+    data_holder: true
+    data_user: true
 - id: 24
   title: Did you reach your FAIRification objectives
   summary: On hold.
@@ -161,4 +366,15 @@
   url: metroline_steps/creating_a_fair_implementation_profile
   icon: ":bookmark_tabs:"
   status: RELEASED
+  keywords:
+    - standards
+    - interoperability
+    - governance
+  expertise_required:
+    - ELSI expert
+    - Researcher
+    - Semantic expert
+  audience:
+    data_holder: true
+    data_user: true
 

--- a/_includes/metroline_steps/step-metadata.html
+++ b/_includes/metroline_steps/step-metadata.html
@@ -11,30 +11,33 @@ Reads optional fields from the step data:
 {% if step.keywords or step.expertise_required or step.audience %}
 <div class="step-metadata">
 
-  {% if step.keywords %}
+    {% if step.audience %}
   <div class="step-metadata-row">
-    <span class="step-metadata-label">Keywords</span>
+    <span class="step-metadata-label"><i class="fa-solid fa-bullseye"></i>Relevant for</span>
     <span class="step-metadata-value">
-      {% for kw in step.keywords %}<span class="step-metadata-tag">{{ kw }}</span>{% endfor %}
+      {% if step.audience.data_holder %}<span class="step-metadata-audience-chip">✓ Data holder</span>{% endif %}
+      {% if step.audience.data_user %}<span class="step-metadata-audience-chip">✓ Data user</span>{% endif %}
     </span>
   </div>
   {% endif %}
 
+  
   {% if step.expertise_required %}
   <div class="step-metadata-row">
-    <span class="step-metadata-label">Expertise required</span>
+    <span class="step-metadata-label"><i class="fa-solid fa-user-gear"></i>Expertise required</span>
     <span class="step-metadata-value">
       {% for role in step.expertise_required %}<span class="step-metadata-tag step-metadata-tag--role">{{ role }}</span>{% endfor %}
     </span>
   </div>
   {% endif %}
 
-  {% if step.audience %}
+
+
+  {% if step.keywords %}
   <div class="step-metadata-row">
-    <span class="step-metadata-label">Relevant for</span>
+    <span class="step-metadata-label"><i class="fa-solid fa-tags"></i>Keywords</span>
     <span class="step-metadata-value">
-      {% if step.audience.data_holder %}<span class="step-metadata-audience-chip">Data holder</span>{% endif %}
-      {% if step.audience.data_user %}<span class="step-metadata-audience-chip">Data user</span>{% endif %}
+      {% for kw in step.keywords %}<span class="step-metadata-tag">{{ kw }}</span>{% endfor %}
     </span>
   </div>
   {% endif %}

--- a/_includes/metroline_steps/step-metadata.html
+++ b/_includes/metroline_steps/step-metadata.html
@@ -15,8 +15,8 @@ Reads optional fields from the step data:
   <div class="step-metadata-row">
     <span class="step-metadata-label"><i class="fa-solid fa-bullseye"></i>Relevant for</span>
     <span class="step-metadata-value">
-      {% if step.audience.data_holder %}<span class="step-metadata-audience-chip">✓ Data holder</span>{% endif %}
-      {% if step.audience.data_user %}<span class="step-metadata-audience-chip">✓ Data user</span>{% endif %}
+      {% if step.audience.data_holder %}<span class="step-metadata-audience-chip">✓ data holder</span>{% endif %}
+      {% if step.audience.data_user %}<span class="step-metadata-audience-chip">✓ data user</span>{% endif %}
     </span>
   </div>
   {% endif %}

--- a/_includes/metroline_steps/step-metadata.html
+++ b/_includes/metroline_steps/step-metadata.html
@@ -4,11 +4,11 @@ Usage: {% raw %}{% include metroline_steps/step-metadata.html step=current_step 
 
 Reads optional fields from the step data:
   keywords   – list of keyword strings
-  core_roles – list of role name strings
+  expertise_required – list of role name strings
   audience.data_holder / audience.data_user – booleans
 -->
 {% assign step = include.step %}
-{% if step.keywords or step.core_roles or step.audience %}
+{% if step.keywords or step.expertise_required or step.audience %}
 <div class="step-metadata">
 
   {% if step.keywords %}
@@ -20,11 +20,11 @@ Reads optional fields from the step data:
   </div>
   {% endif %}
 
-  {% if step.core_roles %}
+  {% if step.expertise_required %}
   <div class="step-metadata-row">
-    <span class="step-metadata-label">Core roles</span>
+    <span class="step-metadata-label">Expertise required</span>
     <span class="step-metadata-value">
-      {% for role in step.core_roles %}<span class="step-metadata-tag step-metadata-tag--role">{{ role }}</span>{% endfor %}
+      {% for role in step.expertise_required %}<span class="step-metadata-tag step-metadata-tag--role">{{ role }}</span>{% endfor %}
     </span>
   </div>
   {% endif %}

--- a/_includes/metroline_steps/step-metadata.html
+++ b/_includes/metroline_steps/step-metadata.html
@@ -1,0 +1,43 @@
+<!--
+Renders a compact metadata bar for a metroline step.
+Usage: {% raw %}{% include metroline_steps/step-metadata.html step=current_step %}{% endraw %}
+
+Reads optional fields from the step data:
+  keywords   – list of keyword strings
+  core_roles – list of role name strings
+  audience.data_holder / audience.data_user – booleans
+-->
+{% assign step = include.step %}
+{% if step.keywords or step.core_roles or step.audience %}
+<div class="step-metadata">
+
+  {% if step.keywords %}
+  <div class="step-metadata-row">
+    <span class="step-metadata-label">Keywords</span>
+    <span class="step-metadata-value">
+      {% for kw in step.keywords %}<span class="step-metadata-tag">{{ kw }}</span>{% endfor %}
+    </span>
+  </div>
+  {% endif %}
+
+  {% if step.core_roles %}
+  <div class="step-metadata-row">
+    <span class="step-metadata-label">Core roles</span>
+    <span class="step-metadata-value">
+      {% for role in step.core_roles %}<span class="step-metadata-tag step-metadata-tag--role">{{ role }}</span>{% endfor %}
+    </span>
+  </div>
+  {% endif %}
+
+  {% if step.audience %}
+  <div class="step-metadata-row">
+    <span class="step-metadata-label">Relevant for</span>
+    <span class="step-metadata-value">
+      {% if step.audience.data_holder %}<span class="step-metadata-audience-chip">Data holder</span>{% endif %}
+      {% if step.audience.data_user %}<span class="step-metadata-audience-chip">Data user</span>{% endif %}
+    </span>
+  </div>
+  {% endif %}
+
+</div>
+{% endif %}

--- a/_sass/_custom_classes.scss
+++ b/_sass/_custom_classes.scss
@@ -21,6 +21,7 @@
 @import "components/homepage";
 @import "components/tool-table";
 @import "components/glossary-tooltips";
+@import "components/step-metadata";
 
 // Fix "On this page" button text color
 #btn-toc-hide.bg-light {

--- a/_sass/components/_step-metadata.scss
+++ b/_sass/components/_step-metadata.scss
@@ -1,0 +1,58 @@
+// Compact metadata bar shown at the top of each metroline step page
+.step-metadata {
+  border: 1px solid #dee2e6;
+  border-radius: 6px;
+  padding: 0.75rem 1rem;
+  margin: 0.75rem 0 1.25rem;
+  background-color: #f8f9fa;
+  font-size: 0.875em;
+}
+
+.step-metadata-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.3rem 0;
+
+  & + & {
+    border-top: 1px solid #e9ecef;
+  }
+}
+
+.step-metadata-label {
+  font-weight: 600;
+  color: #495057;
+  min-width: 8rem;
+  flex-shrink: 0;
+}
+
+.step-metadata-value {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+}
+
+// Keyword pills
+.step-metadata-tag {
+  display: inline-block;
+  padding: 0.15em 0.6em;
+  border-radius: 1rem;
+  background-color: #e2e8f0;
+  color: #2d3748;
+
+  &--role {
+    background-color: #dbeafe;
+    color: #1e40af;
+  }
+}
+
+// Audience chips
+.step-metadata-audience-chip {
+  display: inline-block;
+  padding: 0.15em 0.7em;
+  border-radius: 1rem;
+  background-color: #d1fae5;
+  color: #065f46;
+  font-weight: 500;
+}

--- a/_sass/components/_step-metadata.scss
+++ b/_sass/components/_step-metadata.scss
@@ -1,30 +1,33 @@
 // Compact metadata bar shown at the top of each metroline step page
 .step-metadata {
-  border: 1px solid #dee2e6;
-  border-radius: 6px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.6rem 1.5rem;
+  border-left: 3px solid #328cc1;
+  border-radius: 0 6px 6px 0;
   padding: 0.75rem 1rem;
   margin: 0.75rem 0 1.25rem;
-  background-color: #f8f9fa;
+  background-color: #f5f8fd;
   font-size: 0.875em;
 }
 
 .step-metadata-row {
   display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.5rem;
-  padding: 0.3rem 0;
-
-  & + & {
-    border-top: 1px solid #e9ecef;
-  }
+  flex-direction: column;
+  gap: 0.4rem;
 }
 
 .step-metadata-label {
-  font-weight: 600;
-  color: #495057;
-  min-width: 8rem;
-  flex-shrink: 0;
+  font-weight: 700;
+  color: #183d76;
+  font-size: 0.8em;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+
+  i {
+    color: #328cc1;
+    margin-right: 0.4em;
+  }
 }
 
 .step-metadata-value {
@@ -33,26 +36,27 @@
   gap: 0.35rem;
 }
 
-// Keyword pills
+// Keyword and role pills — outlined
 .step-metadata-tag {
   display: inline-block;
-  padding: 0.15em 0.6em;
+  padding: 0.2em 0.75em;
   border-radius: 1rem;
-  background-color: #e2e8f0;
-  color: #2d3748;
+  border: 1.5px solid #b8d0f0;
+  background-color: transparent;
+  color: #183d76;
 
   &--role {
-    background-color: #dbeafe;
+    border-color: #93c5fd;
     color: #1e40af;
   }
 }
 
-// Audience chips
+// Audience chips — filled green with checkmark
 .step-metadata-audience-chip {
   display: inline-block;
-  padding: 0.15em 0.7em;
+  padding: 0.2em 0.75em;
   border-radius: 1rem;
-  background-color: #d1fae5;
+  background-color: #bbf7d0;
   color: #065f46;
   font-weight: 500;
 }

--- a/pages/metroline_steps/analyse_data_semantics.md
+++ b/pages/metroline_steps/analyse_data_semantics.md
@@ -7,6 +7,7 @@ page_id: analyse_data_semantics
 {% include glossary_tooltips.html %}
 {% include assign_current_step.html %}
 {% include development_status.html step=current_step %}
+{% include metroline_steps/step-metadata.html step=current_step %}
 
 >***… selecting a relevant subset of the data and defining driving user questions(s) are highly relying on being familiar with the data ([Generic](https://direct.mit.edu/dint/article/2/1-2/56/9988/A-Generic-Workflow-for-the-Data-FAIRification))***
 > 

--- a/pages/metroline_steps/apply_common_data_elements.md
+++ b/pages/metroline_steps/apply_common_data_elements.md
@@ -6,6 +6,7 @@ permalink: /metroline_steps/apply_common_data_elements
 {% include glossary_tooltips.html %}
 {% include assign_current_step.html %}
 {% include development_status.html step=current_step %}
+{% include metroline_steps/step-metadata.html step=current_step %}
 
 >***The use of Common Data Elements (CDEs) can facilitate cross study comparisons, data aggregation and meta-analyses, simplify training and operations, improve overall efficiency, promote interoperability between different systems, and improve the quality of data collection. [Sheehan et al., 2016](https://pmc.ncbi.nlm.nih.gov/articles/PMC5133155/)***
 >

--- a/pages/metroline_steps/apply_metadata_model.md
+++ b/pages/metroline_steps/apply_metadata_model.md
@@ -6,6 +6,7 @@ permalink: /metroline_steps/apply_metadata_model
 {% include glossary_tooltips.html %}
 {% include assign_current_step.html %}
 {% include development_status.html step=current_step %}
+{% include metroline_steps/step-metadata.html step=current_step %}
 
 >***A meta(data) model is intended to ‘answer questions about a domain, improve understanding, and promote knowledge sharing; expose \[…] assumptions about a domain; promote communication among people developing a conceptual model, or among people who (later) use a conceptual model' [On the Philosophical Foundations of Conceptual Models](https://ebooks.iospress.nl/volumearticle/53687)***
 >

--- a/pages/metroline_steps/assess_availability_of_your_metadata.md
+++ b/pages/metroline_steps/assess_availability_of_your_metadata.md
@@ -6,6 +6,7 @@ permalink: /metroline_steps/assess_availability_of_your_metadata
 {% include glossary_tooltips.html %}
 {% include assign_current_step.html %}
 {% include development_status.html step=current_step %}
+{% include metroline_steps/step-metadata.html step=current_step %}
 
 >***Metadata is the descriptor, and data is the thing being described' [FAIR Principles: Interpretations and Implementation Considerations](https://www.sciengine.com/DI/doi/10.1162/dint_r_00024)***
 > 

--- a/pages/metroline_steps/assess_fairness.md
+++ b/pages/metroline_steps/assess_fairness.md
@@ -6,6 +6,7 @@ permalink: /metroline_steps/assess_fairness
 {% include glossary_tooltips.html %}
 {% include assign_current_step.html %}
 {% include development_status.html step=current_step %}
+{% include metroline_steps/step-metadata.html step=current_step %}
 
 >***Without this phase, there is a danger of work continuing beyond the point where the benefits to the project justify the continued expenditure of resources. ([FAIR in action](https://pmc.ncbi.nlm.nih.gov/articles/PMC10199076/))***
 > 

--- a/pages/metroline_steps/create_or_reuse_a_semantic_model.md
+++ b/pages/metroline_steps/create_or_reuse_a_semantic_model.md
@@ -6,6 +6,7 @@ permalink: /metroline_steps/create_or_reuse_a_semantic_model
 {% include glossary_tooltips.html %}
 {% include assign_current_step.html %}
 {% include development_status.html step=current_step %}
+{% include metroline_steps/step-metadata.html step=current_step %}
 
 >***'Generating a semantic model is often the most time-consuming step of data FAIRification. However, we expect the modelling effort to diminish as more and more models are made available for reuse over time. Thus, it is important to first check whether a semantic model already exists for the data and the metadata that may be reused. For cases where no semantic model is available a new one needs to be generated.' [Jacobsen et al. Data Intelligence (2020)](https://direct.mit.edu/dint/article/2/1-2/56/9988/A-Generic-Workflow-for-the-Data-FAIRification)***
 >

--- a/pages/metroline_steps/creating_a_fair_implementation_profile.md
+++ b/pages/metroline_steps/creating_a_fair_implementation_profile.md
@@ -6,6 +6,7 @@ permalink: /metroline_steps/creating_a_fair_implementation_profile
 {% include glossary_tooltips.html %}
 {% include assign_current_step.html %}
 {% include development_status.html step=current_step %}
+{% include metroline_steps/step-metadata.html step=current_step %}
 
 >***Ready-made and well-tested FIPs created by trusted communities will find widespread reuse among other communities and could vastly accelerate decision making on well-informed implementations of the FAIR Principles within and particularly between domains. [Reusable FAIR Implementation Profiles as Accelerators of FAIR Convergence](https://link.springer.com/chapter/10.1007/978-3-030-65847-2_13)***
 >

--- a/pages/metroline_steps/data_access_and_retrieval.md
+++ b/pages/metroline_steps/data_access_and_retrieval.md
@@ -6,6 +6,7 @@ permalink: /metroline_steps/data_access_and_retrieval
 {% include glossary_tooltips.html %}
 {% include assign_current_step.html %}
 {% include development_status.html step=current_step %}
+{% include metroline_steps/step-metadata.html step=current_step %}
 
 >***Data locked away benefits no one, but when data is shared responsibly and carefully with bright minds everywhere, we get results that will give us all a healthier future. ([UK Biobank is safely sharing health data to drive medical research](https://www.theguardian.com/science/2025/apr/18/uk-biobank-is-safely-sharing-health-data-to-drive-medical-research))***
 >

--- a/pages/metroline_steps/define_access_conditions.md
+++ b/pages/metroline_steps/define_access_conditions.md
@@ -6,6 +6,7 @@ permalink: /metroline_steps/define_access_conditions
 {% include glossary_tooltips.html %}
 {% include assign_current_step.html %}
 {% include development_status.html step=current_step %}
+{% include metroline_steps/step-metadata.html step=current_step %}
 
 >***The “A” of FAIR – As Open as Possible, as Closed as Necessary. ([Landi et al. 2019](https://doi.org/10.1162/dint_a_00027))***
 >

--- a/pages/metroline_steps/define_fairification_objectives.md
+++ b/pages/metroline_steps/define_fairification_objectives.md
@@ -6,6 +6,7 @@ permalink: /metroline_steps/define_fairification_objectives
 {% include glossary_tooltips.html %}
 {% include assign_current_step.html %}
 {% include development_status.html step=current_step %}
+{% include metroline_steps/step-metadata.html step=current_step %}
 
 >***A FAIRification objective is the end goal that the owners of a resource \[e.g. dataset, database, protocols, analysis workflow] are looking to achieve with the process of FAIRification. ([EJP RD FAIRification Guidelines](https://github.com/ejp-rd-vp/FAIRificationGuidance/blob/main/FAIRificationObjectives.pdf))***
 >

--- a/pages/metroline_steps/design_ecrf.md
+++ b/pages/metroline_steps/design_ecrf.md
@@ -6,6 +6,7 @@ permalink: /metroline_steps/design_ecrf
 {% include glossary_tooltips.html %}
 {% include assign_current_step.html %}
 {% include development_status.html step=current_step %}
+{% include metroline_steps/step-metadata.html step=current_step %}
 
 >***… It is increasingly recognized that the design of the CRF or eCRF is a key quality step in ensuring the data required by the protocol, regulatory compliance and/or safety needs/ comments, study scientific-specific hypothesis attributes, site work flow, and cross-checking of data items within a form or across different forms are addressed. ([Clinical data management: Current status, challenges, and future directions from industry perspectives](https://doi.org/10.2147/OAJCT.S8172))***
 > 

--- a/pages/metroline_steps/design_solution_plan.md
+++ b/pages/metroline_steps/design_solution_plan.md
@@ -6,6 +6,7 @@ permalink: /metroline_steps/design_solution_plan
 {% include glossary_tooltips.html %}
 {% include assign_current_step.html %}
 {% include development_status.html step=current_step %}
+{% include metroline_steps/step-metadata.html step=current_step %}
 
 >***FAIRification planning should not only focus on the selection of suitable technologies or standards, but also on prioritising the effort required to raise the FAIR level of the targeted resources for the realisation of the related objectives. [A goal-oriented method for FAIRification planning](https://doi.org/10.21203/rs.3.rs-3092538/v1)***
 >

--- a/pages/metroline_steps/have_a_fair_data_steward_on_board.md
+++ b/pages/metroline_steps/have_a_fair_data_steward_on_board.md
@@ -6,6 +6,7 @@ permalink: /metroline_steps/have_a_fair_data_steward_on_board
 {% include glossary_tooltips.html %}
 {% include assign_current_step.html %}
 {% include development_status.html step=current_step %}
+{% include metroline_steps/step-metadata.html step=current_step %}
 
 >***Data stewardship is a relatively new profession and a catch-all term for numerous support functions, roles and activities. It implies professional and careful treatment of data throughout all stages of a research process. The core responsibilities and tasks vary, from policy advising and consultancy, to operational and technical support and IT related tasks. Responsibilities also vary between and among the different research-performing organisations, and data stewards (DS) often have different job titles. ([RDMkit](https://rdmkit.elixir-europe.org/data_steward))***
 >

--- a/pages/metroline_steps/obtain_informed_consent.md
+++ b/pages/metroline_steps/obtain_informed_consent.md
@@ -6,6 +6,7 @@ permalink: /metroline_steps/obtain_informed_consent
 {% include glossary_tooltips.html %}
 {% include assign_current_step.html %}
 {% include development_status.html step=current_step %}
+{% include metroline_steps/step-metadata.html step=current_step %}
 
 >***Obtaining consent is not only an ethical obligation, but also a legal compulsion. [Informed Consent: An Ethical Obligation or Legal Compulsion?](https://pmc.ncbi.nlm.nih.gov/articles/PMC2840885/)***
 >

--- a/pages/metroline_steps/organise_training.md
+++ b/pages/metroline_steps/organise_training.md
@@ -6,6 +6,7 @@ permalink: /metroline_steps/organise_training
 {% include glossary_tooltips.html %}
 {% include assign_current_step.html %}
 {% include development_status.html step=current_step %}
+{% include metroline_steps/step-metadata.html step=current_step %}
 
 >***People, with their enduring cultures and practices, and the enormous variety of perspectives on their environment (including a concept such as data) still play a key role in whether technological developments and the information infrastructures that accompany them work as intended. [Bowker and Star, 2000](https://journals.sagepub.com/doi/full/10.1177/20539517251349157#bibr10-20539517251349157)***
 >

--- a/pages/metroline_steps/pre_fair_assessment.md
+++ b/pages/metroline_steps/pre_fair_assessment.md
@@ -6,6 +6,7 @@ permalink: /metroline_steps/pre_fair_assessment
 {% include glossary_tooltips.html %}
 {% include assign_current_step.html %}
 {% include development_status.html step=current_step %}
+{% include metroline_steps/step-metadata.html step=current_step %}
 
 >***FAIR evaluation results can serve as a pointer to where your FAIRness can be improved. ([FAIRopoly](https://www.ejprarediseases.org/fairopoly/))***
 > 

--- a/pages/metroline_steps/query_over_resources.md
+++ b/pages/metroline_steps/query_over_resources.md
@@ -6,6 +6,7 @@ permalink: /metroline_steps/query_over_resources
 {% include glossary_tooltips.html %}
 {% include assign_current_step.html %}
 {% include development_status.html step=current_step %}
+{% include metroline_steps/step-metadata.html step=current_step %}
 
 >***Research is formalized curiosity. It is poking and prying with a purpose. [Zora Neale Hurston](https://www.floridamemory.com/learn/exhibits/in-her-own-words/zora-neale-hurston/)***
 >

--- a/pages/metroline_steps/register_resource_level_metadata.md
+++ b/pages/metroline_steps/register_resource_level_metadata.md
@@ -8,6 +8,7 @@ permalink: /metroline_steps/register_resource_level_metadata
 {% include glossary_tooltips.html %}
 {% include assign_current_step.html %}
 {% include development_status.html step=current_step %}
+{% include metroline_steps/step-metadata.html step=current_step %}
 
 >***Perfectly good data resources may go unused simply because no one knows they exist. There are many ways in which digital resources can be made discoverable, including indexing. ([GO FAIR](https://www.go-fair.org/fair-principles/f4-metadata-registered-indexed-searchable-resource/))***
 > 

--- a/pages/metroline_steps/register_structural_metadata.md
+++ b/pages/metroline_steps/register_structural_metadata.md
@@ -6,6 +6,7 @@ permalink: /metroline_steps/register_structural_metadata
 {% include glossary_tooltips.html %}
 {% include assign_current_step.html %}
 {% include development_status.html step=current_step %}
+{% include metroline_steps/step-metadata.html step=current_step %}
 
 >***Structural metadata are data about how a dataset or resource came about, but also how it is internally structured. [How to FAIR](https://howtofair.dk/how-to-fair/metadata/)***
 >

--- a/pages/metroline_steps/transform_and_expose_fair_metadata.md
+++ b/pages/metroline_steps/transform_and_expose_fair_metadata.md
@@ -6,6 +6,7 @@ permalink: /metroline_steps/transform_and_expose_fair_metadata
 {% include glossary_tooltips.html %}
 {% include assign_current_step.html %}
 {% include development_status.html step=current_step %}
+{% include metroline_steps/step-metadata.html step=current_step %}
 
 >***Data that is not exposed in a standardised, machine-readable way might as well not exist. [The FAIR Guiding Principles for scientific data management and stewardship](https://www.nature.com/articles/sdata201618)***
 >

--- a/pages/metroline_steps/use_ontologies_in_the_model.md
+++ b/pages/metroline_steps/use_ontologies_in_the_model.md
@@ -6,6 +6,7 @@ permalink: /metroline_steps/use_ontologies_in_the_model
 {% include glossary_tooltips.html %}
 {% include assign_current_step.html %}
 {% include development_status.html step=current_step %}
+{% include metroline_steps/step-metadata.html step=current_step %}
 
 >***Ontologies provide a flexible approach to integrating data and sharing meaning and may be better able to assist in inferring meaning in complex situations. [Liyanage H, Krause P, de Lusignan S. Using ontologies to improve semantic interoperability in health data. BMJ Health & Care Informatics.](https://doi.org/10.14236/jhi.v22i2.159)***
 >


### PR DESCRIPTION
Introducing the metadata annotations. In case we want all roles to have a tooltip, we should add them to the Glossary. Currently we have `Data steward` and `metadata`

<img width="1479" height="716" alt="Screenshot 2026-05-29 at 10 38 17" src="https://github.com/user-attachments/assets/9c358132-2b2b-4173-bf4c-8ed9736e5218" />

