### PR TITLE
Removed "Expertise required" sections from all guidance pages

### DIFF
--- a/_data/metroline_steps.yml
+++ b/_data/metroline_steps.yml
@@ -16,12 +16,6 @@
   audience:
     data_holder: true
     data_user: true
-- id: 2
-  title: Build the Team
-  summary: Coming soon.
-  url:
-  icon: ":running_shirt_with_sash:"
-  status: IN DEVELOPMENT
 - id: 3
   title: Have a FAIR data steward on board
   summary: A FAIR data steward guides teams in organising, storing, and describing data to meet the FAIR principles, ensuring research data can be understood and reused, making science more efficient and transparent.
@@ -263,12 +257,6 @@
   audience:
     data_holder: true
     data_user: false
-- id: 18
-  title: Enter data in eCRF (data collection)
-  summary: On hold.
-  url: 
-  icon: ":computer:"
-  status: ON HOLD
 - id: 19
   title: Apply (meta)data model
   summary: Think of your data like a book in a library. A metadata model defines the kind of information included in the catalogue entry, such as the title, author, topic, and publication date, helping people find and understand the book. A data model defines how the contents of the book are organised and related, like the structure of chapters, sections, and references. Using both makes it easier for people and machines to find, understand, and reuse your data.
@@ -354,12 +342,6 @@
   audience:
     data_holder: true
     data_user: true
-- id: 24
-  title: Did you reach your FAIRification objectives
-  summary: On hold.
-  url: 
-  icon: ":checkered_flag:"
-  status: ON HOLD
 - id: 25
   title: Creating a FAIR Implementation Profile (FIP)
   summary: A FAIR Implementation Profile (FIP) describes the practical choices a community makes to apply the FAIR data principles using shared standards and tools. It lists the specific resources, such as metadata schemas, ontologies and licences, that make data findable, accessible, interoperable and reusable. Other communities can reuse these profiles to align their practices, fill gaps and improve collaboration.

--- a/pages/metroline_steps/analyse_data_semantics.md
+++ b/pages/metroline_steps/analyse_data_semantics.md
@@ -200,12 +200,6 @@ From here, there are three possible next steps, depending on your needs:
 Great job! After checking and improving our metadata semantics, we can now move to the next Metroline step.
 "%}
 
-## Expertise requirements for this step 
-Below are experts that may need to be involved, as described in [Metroline Step: Build the Team]({{site.baseurl}}/metroline_steps/build_the_team).
-* **Semantic data / modelling specialists.** Can help understanding the data’s structure and ambiguity.
-* **Domain expert.** Can help understanding the data’s elements and their potential ambiguity.
-* **FAIR data steward.** Can help identifying ambiguity in the data elements.
-
 ## Practical examples from the community
 {% include metroline_steps/looking_for_examples.html %}
 

--- a/pages/metroline_steps/apply_common_data_elements.md
+++ b/pages/metroline_steps/apply_common_data_elements.md
@@ -228,11 +228,6 @@ The [initial data elements](https://eu-rd-platform.jrc.ec.europa.eu/set-of-commo
 
 {% include info-box.html type="example" title="Example" text=infobox_text1 %}
 
-## Expertise requirements for this step 
-Experts that may need to be involved, as described in Metroline Step: Build the Team, are described below.
-* **Researcher.** Understands the scientific context of the data being collected.
-* **Data steward.** Ensures the technical accuracy and consistency of how CDEs are applied.
-
 ## Practical examples from the community 
 **Patient Registries on Rare Diseases**<br>
 The Joint Research Centre has defined [Common Data Elements to be collected by all Rare Disease (RD) registries](https://eu-rd-platform.jrc.ec.europa.eu/set-of-common-data-elements_en) and collecting them will improve interoperability with other ERN registries that are obligated to collect these data items. So far, 16 minimal Rare Disease data elements have been identified as essential for further research in the field. This list includes the variables to be collected and how they should be annotated.

--- a/pages/metroline_steps/apply_metadata_model.md
+++ b/pages/metroline_steps/apply_metadata_model.md
@@ -147,14 +147,6 @@ The following tools provide support in applying a (meta)data model to your resou
 </table>
 </div>
 
-## Expertise requirements for this step 
-Applying metadata and data models effectively requires a mix of domain knowledge and technical skills. Ideally, teams should involve:
-* **Domain experts.** Understand the research content and can guide the correct interpretation of terms and relationships.
-* **(Meta)Data modellers and ontologists.** Can help select or customise the right models and ontologies to fit the data.
-* **Data engineers or FAIR data stewards.** Are familiar with tools, knowledge representation formats, and transformation workflows.
-
-While basic metadata tasks (e.g. filling in a dataset description using a web form) may not require a deep technical knowledge, more advanced modelling—such as mapping raw data to ontological terms or generating knowledge graphs—typically benefits from the experience described above. 
-
 ## Practical examples from the community
 **FAIR Data Point**<br>
 The UMCs in the Netherlands are either in the process of setting up or already have a local FDP. For example, see [Amsterdam UMC’s FDP](https://fdp.healthdataspace.amsterdam/). Health-RI provides [guidance](https://health-ri.atlassian.net/wiki/spaces/FSD/pages/279183386) for setting up the FDP for the National Health Data Catalogue. 

--- a/pages/metroline_steps/assess_availability_of_your_metadata.md
+++ b/pages/metroline_steps/assess_availability_of_your_metadata.md
@@ -70,10 +70,6 @@ You are now ready to take the next step with your metadata:
 * **Expand your metadata to include domain specific metadata.** [Domain-specific metadata schema development](https://health-ri.atlassian.net/wiki/spaces/FSD/pages/545783826)
 * **follow a semantic model to describe your metadata (under construction.** [Metroline Step: Create or reuse a semantic (meta)data model]({{site.baseurl}}/metroline_steps/create_or_reuse_a_semantic_model) )
 
-## Expertise requirements for this step 
-Experts that may need to be involved, as described in [Metroline Step: Build the Team]({{site.baseurl}}/metroline_steps/build_the_team), are described below.
-* Data manager/Data steward/Data librarian, Researcher (Scientist) or someone else who knows the context and content of the project.
-
 ## Practical examples from the community 
 * The [Health-RI metadata schema](https://github.com/Health-RI/health-ri-metadata) is an example of **descriptive metadata** within the context of the [Dutch National Health Data Infrastructure](https://www.healthdata.nl/en).
 * An example of **administrative metadata** is provided by [ArrayExpress](https://www.ebi.ac.uk/biostudies/arrayexpress/studies/E-MTAB-11745), which includes details such as experimental protocols.

--- a/pages/metroline_steps/assess_fairness.md
+++ b/pages/metroline_steps/assess_fairness.md
@@ -64,12 +64,6 @@ Even if your FAIRification efforts are complete for now, evolving requirements, 
 
 To help keep an overview of the original FAIRification objectives, their status, and possible changes in the process, it might be useful to update this information in your datamanagement plan. Consider going back to [Metroline Step: Define FAIRification objectives]({{site.baseurl}}/metroline_steps/define_fairification_objectives) to redefine the original FAIR objectives.
 
-## Expertise requirements for this step 
-The expertise required may depend on the assessment tool you want to use. Experts that may need to be involved, as described in [Metroline Step: Build the Team]({{site.baseurl}}/metroline_steps/build_the_team), are described below. 
-* **Researcher.** Understands the data content and how it should be used. 
-* **FAIR data stewards.** Specialist who can help filling out the FAIR assessment tools (see also [Metroline step: Pre-FAIR assessment]({{site.baseurl}}/metroline_steps/pre_fair_assessment)) 
-* **Research software engineers.** Specialists who can help running some of the specialised software. 
-
 ## Practical examples from the community 
 For an applied example of The FAIR Evaluator tool, see Applying the FAIR principles to data in a hospital: challenges and opportunities in a pandemic. 
 

--- a/pages/metroline_steps/build_the_team.md
+++ b/pages/metroline_steps/build_the_team.md
@@ -1,6 +1,0 @@
----
-title: Build the team
-permalink: /metroline_steps/build_the_team
----
-
-The website version is currently experimental and this page is not available yet. Find [Build the team](https://health-ri.atlassian.net/wiki/spaces/FSD/pages/273350662/Metroline+Step+Build+the+team) on Confluence instead.

--- a/pages/metroline_steps/create_or_reuse_a_semantic_model.md
+++ b/pages/metroline_steps/create_or_reuse_a_semantic_model.md
@@ -128,24 +128,6 @@ Even when your data cannot be openly shared (e.g. due to privacy or legal restri
 The HRI Clinic modelling team decides to use RDF to structure their data into triples and OWL to define their data's rules and relationships. The clinic publishes their simplified version of CARE-SM on GitHub (including a clear license, version and credit to the original model).
 " %}
 
-## Expertise requirements for this step
-Creating or reusing a semantic (meta)data model typically involves multiple experts, as described in [Metroline Step: Build the Team]({{site.baseurl}}/metroline_steps/build_the_team).
-
-- **Metadata experts.** Bring a strong understanding of what metadata is, how it differs from data, and how it supports documentation, discovery, and reuse by both humans and machines. This expertise is essential from the start of the modelling process, as it underpins how data is meaningfully described and exposed.
-  - *When reusing or extending a model*: for instance, help assess whether existing metadata fits the intended purposes.
-  - *When creating a model*: for instance, support the definition of metadata for the model itself, including license and authorship.
-- **Semantic modelling experts.** Understand how to use conceptual and ontological modelling approaches to define the precise meaning of data elements. Familiar with modelling languages such as UML (conceptual models) and OWL (ontologies), they ensure the model is unambiguous and interoperable across tools and systems.
-  - *When reusing or extending a model*: check if reused or added concepts are fit for purpose and their definitions ontologically sound.
-  - *When creating a model*: help define the scope, structure, and relations in line with modelling best practices.
-- **Vocabulary and ontology experts.** Know how to identify and assess semantic resources, such as general-purpose vocabularies (e.g. DCAT) and domain-specific ontologies (e.g. DDI, SNOMED CT), and how to align terms with them.
-  - *When reusing, extending or creating a model*:
-    - Help evaluate if vocabularies capture intended meanings and whether local schema elements can be mapped to existing standards.
-    - Promote consistency and reuse across systems, especially in regulated domains such as health or environmental sciences, where adherence to community standards is often required.
-- **Semantic web technology experts.** Have experience implementing models using RDF, OWL, and SHACL, core standards for making models machine-readable and technically valid. This expertise is particularly relevant when implementing, extending, or validating the structure of a selected model in a semantic framework.
-  - *When reusing, extending or creating a model*:
-    - Help represent mappings explicitly between internal schema elements and external vocabularies.
-    - Ensure structure and constraints are formally expressed and validated, in alignment with the FAIR principles.
-
 ## Practical examples from the community
 Below are examples of how research communities and infrastructures have created or reused semantic (meta)data models to improve interoperability and support FAIR implementation. These cases demonstrate reuse, extension, alignment with standards, and use of semantic web technologies.
 

--- a/pages/metroline_steps/creating_a_fair_implementation_profile.md
+++ b/pages/metroline_steps/creating_a_fair_implementation_profile.md
@@ -45,12 +45,6 @@ The FIP Wizard provides a more advanced and structured environment. You will nee
 ### Step 3 - Publish your FIP for reuse
 Once you’ve created your FIP using the FIP Wizard, you can publish it to make it available for reuse. When you choose to publish, the Wizard packages your FIP as a machine-actionable nanopublication and submits it to the public nanopublication network. After publication, your FIP and the FAIR-enabling resources it references become automatically searchable and reusable through [FAIR Connect](https://fairconnect.pro/) and [Nanodash](https://nanodash.knowledgepixels.com/). 
 
-## Expertise requirements for this step 
-Experts that may need to be involved, as described in [Metroline Step: Build the Team]({{site.baseurl}}/metroline_steps/build_the_team), are described below.
-* researcher with domain knowledge;
-* semantic expert / metadata expert;
-* ELSI expert for e.g. licensing questions.
-
 ## Practical examples from the community 
 * The Virus Outbreak Data Network ([VODAN](https://www.go-fair.org/implementation-networks/overview/vodan/))-Africa is a joint activity of CODATA, RDA, WDS, and GO FAIR which has implemented FIPs for their [VODAN-Africa project](https://fip-wizard.ds-wizard.org/projects/9cbf831d-5536-4b97-a5c6-f00522f9ec6b).
 * The WorldFAIR Project, a multi-disciplinary project that crosses 11 domains, is a collaboration between CODATA and RDA. It uses FIPs as a methodology for listing the FAIR implementation decisions made within the project. They have summarized their experiences in [this article](https://doi.org/10.5281/zenodo.7378109).

--- a/pages/metroline_steps/data_access_and_retrieval.md
+++ b/pages/metroline_steps/data_access_and_retrieval.md
@@ -141,15 +141,6 @@ A checksum is a short digital code that works like a fingerprint for a file, let
 The researcher verifies file integrity using checksums and stores derived data and metadata in a secure institutional environment.
 "%}
 
-## Expertise requirements for this step 
-You may need access to or support from:
-* **Data Stewards.** Ensure proper metadata and FAIR practices.
-* **Legal and ethical advisors.** Interpret GDPR and other ethical constraints). 
-* **IT professionals.** Manage secure storage and encrypted transfers.
-* **Domain experts.** Assess data relevance and validity.
-
-Refer to [Metroline Step: Build the Team]({{site.baseurl}}/metroline_steps/build_the_team) for role descriptions and team structure advice.
-
 ## Practical examples from the community 
 {% include metroline_steps/looking_for_examples.html %}
 

--- a/pages/metroline_steps/define_access_conditions.md
+++ b/pages/metroline_steps/define_access_conditions.md
@@ -221,15 +221,6 @@ In case of restricted access data, the Geonovum [link for Non-open data](https:/
 can add a link to the Data Use Agreement (human-readable) or encoded use conditions (machine-readable). 
 See [Step 3](#step-3---prepare-necessary-documentation) for information about machine-readable access conditions.
 
-## Expertise requirements for this step
-The following role from [Metroline Step: Build the Team]({{site.baseurl}}/metroline_steps/build_the_team)) is necessary for this step:
-- **Researcher.** Knowledge about the data/research, and the domain best practices, responsible for implementation of 
-accessibility policy and following-through (e.g. granting access).
-- **Data steward.** Implement or support the Researcher in implementation by providing knowledge about FAIR practices 
-and applicable accessibility regulations.
-- **Data curator.** Support the Researcher in the implementation.
-- **Legal expert.** Advise the Researcher on legal aspects of data sharing and reuse.
-
 ## Practical examples from the community 
 {% include metroline_steps/looking_for_examples.html %}
 

--- a/pages/metroline_steps/define_fairification_objectives.md
+++ b/pages/metroline_steps/define_fairification_objectives.md
@@ -55,19 +55,10 @@ Identify the resources you will need to complete your FAIRification process and 
 * Do you need to hire specific expertise?
 * Do you need specific software or additional hardware to meet your FAIRification objectives?
 
-See [Metroline Step: Build the Team]({{site.baseurl}}/metroline_steps/build_the_team) for more information on team requirements.
-
 ### Step 6 - Create an actionable plan around clear objectives
 Organise and describe the steps and resources identified in the previous step necessary for reaching your FAIRification objective(s). This can be a separate plan (see [Metroline Step: Design Solution Plan]({{site.baseurl}}/metroline_steps/design_solution_plan)) or part of your Data Management Plan (DMP). Make sure to formulate your FAIRification objectives as specifically as possible and, where possible, incorporate research questions. For example:
 * I require interoperable data, because I need to connect two different datasets to answer question X;
 * I want to make my data more findable for researchers in my field by publishing it in repository Z.
-
-## Expertise requirements for this step 
-Defining FAIRification objectives is typically a collaborative effort by a range of experts, as described in [Metroline Step: Build the Team]({{site.baseurl}}/metroline_steps/build_the_team).
-* **Researchers with domain knowledge.** Provide context to the FAIRification efforts from the perspective of a domain.
-* **FAIR data stewards.** Help define FAIRification objectives to meet the project’s, funder’s, journal’s and/or institute’s requirements.
-* **Semantic experts.** Assist in specifying the metadata/modelling aspects of FAIRification objectives.
-* **ELSI experts.** Help identify the legal compliance and ethical aspects of FAIRification objectives.
 
 ## Practical examples from the community 
 Below you can find several examples of projects with the FAIR objectives they set.

--- a/pages/metroline_steps/design_ecrf.md
+++ b/pages/metroline_steps/design_ecrf.md
@@ -233,13 +233,6 @@ Now, when you enter data, you can select the item from the ontology's list. For 
 * **iCRF Generator.** The [iCRF Generator](https://github.com/aderidder/iCRFGenerator/) is a tool that generates eCRFs for various EDC systems such as Castor EDC and REDCap from codebooks published in ART-DECOR and OpenEHR. When codebooks are properly annotated, their annotations are incorporated into the generated CRFs in accordance with the methods described above.
 * **Codebook to Castor/LimeSurvey.** Codebook to Castor/LimeSurvey. Developed by Amsterdam UMC, this tool converts an Excel-based codebook into a format compatible with RadboudUMC’s Castor Offline Design converter, which then generates a Castor-ready XML file. Nowadays, the tool also has limited LimeSurvey support. Currently, the tool is only available within Amsterdam UMC.
 
-## Expertise requirements for this step
-Experts that may need to be involved, as described in [Metroline Step: Build the Team]({{site.baseurl}}/metroline_steps/build_the_team), are described below.
-* **Researcher with domain knowledge.** Specifies the items that need to be collected. 
-* **Data steward with EDC knowledge/ data manager.** Builds the forms in the EDC system. They are also in charge of setting up user access and offer technical help to researchers and ensure data integrity and regulatory compliance. 
-* **FAIR data steward.** Can support team in making eCRF more FAIR. 
-* **Data entry person.** Offers insight into what works and what doesn’t in real-world data collection settings, especially when interacting with patients. While not directly building the forms, their input helps ensure that the eCRF is user-friendly, clear and suitable for practical use. 
-
 ## Practical examples from the community
 * **VASCA registry**. For more information see the following publications:
   * [The de novo FAIRification process of a registry for vascular anomalies](https://doi.org/10.1186/s13023-021-02004-y)

--- a/pages/metroline_steps/design_solution_plan.md
+++ b/pages/metroline_steps/design_solution_plan.md
@@ -84,14 +84,6 @@ For example, when making data FAIR, datasets can be split into smaller sets, imp
 
 **Example:** For GO-Plan, a template was developed to facilitate the identification of FAIRification objectives. This template has been successfully applied in two tutorials, with participants reporting that it effectively guided them through the process.
 
-## Expertise requirements for this step 
-Designing a solution plan is typically a collaborative effort by a range of experts, as described in [Metroline Step: Build the Team]({{site.baseurl}}/metroline_steps/build_the_team).
-* **FAIR experts.** Provide guidance on best practices, standards, and methodologies.
-* **Domain experts.** Define data semantics, quality standards, and use cases.
-* **Data stewards.** Ensure data and metadata comply with FAIR principles.
-* **IT specialists.** Support infrastructure needs, interoperability, and tool integration.
-* **Project managers.** Oversee planning, stakeholder coordination, and implementation tracking.
-
 ## Practical examples from the community 
 This section should show the step applied in a real project. Links to demonstrator projects. 
 

--- a/pages/metroline_steps/have_a_fair_data_steward_on_board.md
+++ b/pages/metroline_steps/have_a_fair_data_steward_on_board.md
@@ -18,7 +18,7 @@ Proper data stewardship ensures research data is Findable, Accessible, Interoper
 ## Why is this step important 
 Good data stewardship incorporates the FAIR data principles and ensures sustainable integration in the research cycle. It is a collective effort requiring actions and competencies from researchers, project teams, institutes, research disciplines and funders. Each organisation tailors its research data management (RDM) policy to its own context, with funders and institutions defining roles and responsibilities differently, such as expectations for research teams, host institutions and third-party organisations like data centres ([Towards FAIR Data Steward as profession for the Lifesciences](https://zenodo.org/records/3474789/files/Report_FAIR%20Data%20Steward%20in%20Lifesciences_v2.pdf)).
 
-Having a FAIR data steward in your multidisciplinary team (see [Metroline Step: Build the team]({{site.baseurl}}/metroline_steps/build_the_team)) offers key benefits (see [FAIRopoly](https://www.ejprarediseases.org/fairopoly/)).
+Having a FAIR data steward in your multidisciplinary team offers key benefits (see [FAIRopoly](https://www.ejprarediseases.org/fairopoly/)).
 * **FAIR expertise.** A team member with general FAIR knowledge and expertise helps achieve FAIR objectives (see [Metroline Step: Define your FAIRification Objectives]({{site.baseurl}}/metroline_steps/define_fairification_objectives)) more easily and faster. 
 * **FAIR standards.** A FAIR data steward provides expertise in metadata standards and semantic modelling, essential for achieving interoperability between collections, studies and datasets.
 * **FAIR technologies.** They also bring knowledge of technologies and tools that automate or improve FAIRness within and beyond the institution.
@@ -88,17 +88,10 @@ Hire or consult a data steward following the formalised Dutch data steward profi
 ### Step 4 - Provide support and resources to the FAIR data steward
 If your team includes a FAIR data steward, ensure they have access to the right support and resources.
 * **Training opportunities.** Ensure data stewards receive continuous training to stay updated on best practices, tools and policies.
-* **Institutional and national networks.** Connect data stewards with institutional, national and international networks to foster collaboration and professional growth. Central networks should be the first point of contact, including institutional data steward groups (via the Local Digital Competence Centers (LDCC) or the Open Science Communities), national networks (e.g. the Data Stewards Interest Group) and international initiatives (e.g. RDA professionalising data stewardship Interest Group or the ELIXIR RDM Community). See the Building your Community page page for more details.
+* **Institutional and national networks.** Connect data stewards with institutional, national and international networks to foster collaboration and professional growth. Central networks should be the first point of contact, including institutional data steward groups (via the Local Digital Competence Centers (LDCC) or the Open Science Communities), national networks (e.g. the Data Stewards Interest Group) and international initiatives (e.g. RDA professionalising data stewardship Interest Group or the ELIXIR RDM Community).
 * **Domain-specific knowledge.** A data steward with expertise in your research field can better understand the data’s context and communicate effectively with researchers and stakeholders.
 * **Funder requirements.** Many funders now require a data steward to be part of the project team. Check grant conditions to ensure compliance with specific expectations.
 * **Publishing policies and local guidance.** Ensure data handling aligns with institutional policies and national and international regulations. Discuss early stage requirements with local guidance bodies to meet FAIR standards and repository guidelines.
-
-## Expertise requirements for this step
-Positioning a FAIR data steward in your team requires aligning their role with your FAIRification objectives and existing support structures, as described in Metroline Step: Build the Team. The following experts may be involved.
-* **FAIR data stewards.** Provide expertise in data management, metadata standards, data integration, repository platforms and privacy/security compliance.
-* **Researchers.** Work with data stewards during data generation, collection and analysis, adopting recommended tools and platforms.
-* **Infrastructure professionals.** Assess and adapt workflows and infrastructure to integrate FAIR data stewardship without duplication of roles.
-* **Project managers.** Coordinate FAIR data implementation, manage responsibilities and ensure policy compliance.
 
 ## Practical examples from the community 
 ***[European Joint Programme on Rare Diseases (EJP RD)](https://www.ejprarediseases.org/)***

--- a/pages/metroline_steps/obtain_informed_consent.md
+++ b/pages/metroline_steps/obtain_informed_consent.md
@@ -172,14 +172,6 @@ With your SIS and ICF fully FAIR ready and approved by your data protection offi
 * An accredited MREC for Non-WMO studies 
 * An accredited MREC or the CCMO for WMO studies
 
-## Expertise requirements for this step 
-The following role from [Metroline Step: Build the Team]({{site.baseurl}}/metroline_steps/build_the_team) is necessary for this step:
-* ELSI expert 
-  * National level
-    * [The ELSI servicedesk](https://elsi.health-ri.nl/) for general information and questions 
-  * Local level
-    * Amsterdam UMC - Privacy Bescherming & Informatie Beveiliging (<privacy@amsterdamumc.nl>)
-
 ## Practical examples from the community 
 * [COMPRAYA’s SIS](https://www.compraya.nl/files/e1-e2ppicomprayastudie_m20com_v1.9_14032023_clean.pdf) (in Dutch) contains a section about, for example, future use of data and materials (page 7).
 

--- a/pages/metroline_steps/organise_training.md
+++ b/pages/metroline_steps/organise_training.md
@@ -13,7 +13,7 @@ permalink: /metroline_steps/organise_training
 > {{ current_step.summary }}
 
 ## Short description 
-After building your team ([Metroline Step: Build the Team]({{site.baseurl}}/metroline_steps/build_the_team)), it is a good idea to assess their training needs. This vital step involves a comprehensive assessment to pinpoint any missing expertise or skill gaps within the different roles in your team. This page creates a broad overview of training solutions that support the development of core competencies in FAIR data management. This page offers guidance on how to locate targeted training options for all roles within a given team. Specialised training that is needed for a specific Metroline Step are listed in the corresponding pages.
+Before starting the actual FAIRification, assess your team's training needs. This vital step involves a comprehensive assessment to pinpoint any missing expertise or skill gaps within the different roles in your team. This page creates a broad overview of training solutions that support the development of core competencies in FAIR data management. This page offers guidance on how to locate targeted training options for all roles within a given team. Specialised training that is needed for a specific Metroline Step are listed in the corresponding pages.
 
 ## Why is this step important
 The journey to making data FAIR is intricate, demanding both a comprehensive understanding of the FAIR principles and the practical skills for their implementation. A specialised FAIRification training will empower your team members to:  
@@ -25,7 +25,7 @@ The journey to making data FAIR is intricate, demanding both a comprehensive und
 ## How to
 
 ### Step 1 - Consider your roles and/or those of team members
-Before diving into specific training modules, it's beneficial to understand the broader landscape of FAIR training for each specific role in your team. A comprehensive overview of roles can be found in [Metroline Step: Build the Team]({{site.baseurl}}/metroline_steps/build_the_team), and different types Data Stewards are described in [Metroline step: Have a FAIR data steward on board]({{site.baseurl}}/metroline_steps/have_a_fair_data_steward_on_board). In case your FAIRification project is on existing data you can also consider doing a Pre-FAIR assessment (see [Metroline step: Pre-FAIR Assessment]({{site.baseurl}}/metroline_steps/pre_fair_assessment)). This assessment can help you identify potential knowledge gaps within your team, allowing you to determine appropriate roles and address any training needs. Once you have a clearer picture of the role(s) in your team and you have pinpointed knowledge gaps, you can more effectively suggest and/or select training modules that address specific needs. 
+Before diving into specific training modules, it's beneficial to understand the broader landscape of FAIR training for each specific role in your team. In case your FAIRification project is on existing data you can also consider doing a Pre-FAIR assessment (see [Metroline step: Pre-FAIR Assessment]({{site.baseurl}}/metroline_steps/pre_fair_assessment)). This assessment can help you identify potential knowledge gaps within your team, allowing you to determine appropriate roles and address any training needs. Once you have a clearer picture of the role(s) in your team and you have pinpointed knowledge gaps, you can more effectively suggest and/or select training modules that address specific needs. 
 
 Here are some of the different roles that people have in research projects and FAIRification of data: 
 * **Researchers.** Researchers are responsible for conducting experiments and generating new knowledge. Responsibilities include collecting, cleaning, and analyzing data. Researchers need to have a good understanding of the FAIR principles in order to make sure that their data is accessible, interoperable, and reusable. 
@@ -80,12 +80,6 @@ You can also consider joining a community of trainers.
 * [Research Software Training NL](https://researchsoftwaretraining.nl/about/) is a network bringing together and facilitating training organisations in the Netherlands in the areas of research software, programming skills, applied data science, computational skills and open source. 
 
 All of these resources are emerging to adapt and tailor FAIR data solutions to meet the specific needs and constraints of every team. Additionally, every step of the Metroline contains training links or information that could be of further use. Ultimately, also contact the Training Coordinator of your institution for more relevant advise. 
-
-## Expertise requirements for this step 
-The expertise required may depend on the training that will be followed, or the task that will be performed. Experts that may need to be involved, as described in [Metroline Step: Build the Team]({{site.baseurl}}/metroline_steps/build_the_team), are described below.
-* **Researcher.** Provides research data and discipline specific knowledge.
-* **Data steward.** Often, data stewards act as trainers for their research group, department, faculty, or university.
-* **Trainer.** Your institutional Training Coordinator that focuses on research data management (if available) knows which training is available for the different roles in the team. They can find or create and organise tailor-made training and evaluate the effectiveness and impact of training. 
 
 ## Practical examples from the community 
 ***Radboud University Medical Center (RadboudUMC)***<br>

--- a/pages/metroline_steps/pre_fair_assessment.md
+++ b/pages/metroline_steps/pre_fair_assessment.md
@@ -145,11 +145,6 @@ To successfully do a pre-FAIR assessment, do the following:
 
 The final evaluation will give insight into the current FAIRness of your data. Depending on the tool used, you may receive feedback on how to improve the FAIRness of your data. Thus, the outcome of the pre-FAIR assessment helps you determine the next steps to achieve your FAIRification goals.
 
-## Expertise requirements for this step
-The expertise required may depend on the assessment tool you want to use. Experts that may need to be involved, as described in [Metroline Step: Build the Team]({{site.baseurl}}/metroline_steps/build_the_team), are described below.
-* **FAIR data stewards.** Specialist who can help filling out the surveys and questionnaires.
-* **Research software engineers.** Specialists who can help running some of the specialised software.
-
 ## Practical examples from the community
 For an applied example of The FAIR Evaluator, see [Applying the FAIR principles to data in a hospital: challenges and opportunities in a pandemic](https://jbiomedsem.biomedcentral.com/articles/10.1186/s13326-022-00263-7).
 

--- a/pages/metroline_steps/query_over_resources.md
+++ b/pages/metroline_steps/query_over_resources.md
@@ -114,14 +114,6 @@ In [Wikidata](https://www.wikidata.org), you can visualise query results in diff
 "%}
 
 
-## Expertise requirements for this step
-To successfully perform this step, you may need help from the following experts:
-* **Researcher/domain expert.** Uses domain knowledge to formulate queries and interpret results.
-* **Data scientist.** Executes queries, processes results and handles federated queries.
-* **Semantic expert.** Ensures correct use of metadata, vocabularies and ontologies for queries.
-
-See [Metroline Step: Build the Team]({{site.baseurl}}/metroline_steps/build_the_team) for more information.
-
 ## Practical examples from the community
 **[SPHN Data Exploration and Analysis System (DEAS)](https://sphn.ch/2024/10/17/sphn-launches-a-new-cross-hospital-data-query-tool-deas/)**. 
 <br>DEAS is a cross-hospital federated query tool developed by the Swiss Personalized Health Network (SPHN) to replace the previous Federated Query System. It enables researchers to securely query aggregated clinical data from multiple Swiss university hospitals without moving patient-level data.

--- a/pages/metroline_steps/register_resource_level_metadata.md
+++ b/pages/metroline_steps/register_resource_level_metadata.md
@@ -146,17 +146,6 @@ Eva followed the [instructions](https://health-ri.atlassian.net/wiki/spaces/FSD/
 Eva entered the biosample data into the BBMRI Catalogue Form, which she [downloaded](), and submitted it to the [Health-RI Service Desk](https://www.health-ri.nl/health-ri-servicedesk). The metadata for biosample data were successfully registered, see  
 [BBMRI-ERIC Directory](https://directory.bbmri-eric.eu/ERIC/directory/#/collection/bbmri-eric:ID:NL_RB:collection:155?search=PRISMA).
 
-## Expertise requirements for this step 
-The level of expertise required for this step will depend on several factors:
-* your department’s familiarity with data-sharing practices;
-* your personal experience with metadata catalogues and metadata elements relevant to your research domain;
-* availability of metadata catalogues within your community.
-
-Depending on these variables, selecting the appropriate metadata catalogue may be a straightforward process or may require input from multiple experts. Experts that may need to be involved, as described in [Metroline Step: Build the Team]({{site.baseurl}}/metroline_steps/build_the_team), are described below.
-* **Researcher with domain knowledge.** Someone that understands the project, study and data to create detailed and comprehensive metadata.
-* **FAIR data steward.** Specialist who can advice on the metadata catalogues to use and can provide advice on how to fill in metadata accurately.
-* **Infrastructure professional.** When no suitable metadata catalogue is available or if you need to connect with federated catalogues (such as the [Health-RI Data Catalogue](https://healthdata.nl/)), specialised IT knowledge may be required. This is particularly important when exposing metadata on the web via a [FAIR Data Point](https://www.fairdatapoint.org/) or integrating with other systems.
-
 ## Practical examples from the community 
 ***[The Netherlands ME/CFS Cohort and Biobank Consortium](https://www.health-ri.nl/en/netherlands-mecfs-cohort-and-biobank-nmcb-consortium)***
 

--- a/pages/metroline_steps/register_structural_metadata.md
+++ b/pages/metroline_steps/register_structural_metadata.md
@@ -275,11 +275,6 @@ Guidance on maintaining metadata integrity can be found in the following Metroli
 
 {% include info-box.html type="example" title="Example" text=infobox_text2 %}
 
-## Expertise requirements for this step 
-This step requires the following experts as described in the [Metroline Step: Build the team]({{site.baseurl}}/metroline_steps/build_the_team) step.
-* **Researcher.** Provide the metadata/codebook.
-* **Data Steward.** Find solutions and implement them or support the Researcher in the implementation.
-
 ## Practical examples from the community 
 {% include metroline_steps/looking_for_examples.html %}
 

--- a/pages/metroline_steps/select_identifier_scheme.md
+++ b/pages/metroline_steps/select_identifier_scheme.md
@@ -184,13 +184,6 @@ pid: https://n2t.net/hdl:20.500.12633/1HK1DTv1wPt3a
 ```
 " %}
  
-
-## Expertise requirements for this step 
-Based on the expertise described in the [Metroline: Build the team]({{site.baseurl}}/metroline_steps/build_the_team), the following expertise may be relevant:
-* **Data specialist.** Understands which identifiers are needed. 
-* **Technical specialist.** Can generate or integrate identifiers in systems. 
-* **Policy specialist.** Ensures identifier use follows agreed rules.
-
 ## Practical examples from the community 
 {% include metroline_steps/looking_for_examples.html %}
 

--- a/pages/metroline_steps/transform_and_expose_fair_metadata.md
+++ b/pages/metroline_steps/transform_and_expose_fair_metadata.md
@@ -90,14 +90,6 @@ Start by transforming metadata into a structured format using semantic web stand
 * **[Castor EDC (FDP Component)](https://fdp.castoredc.com/fdp).** Contains a template to fill out metadata and exposes that information in a way that is semantically compatible with DCAT and FDP specifications. 
 "%}
 
-## Expertise requirements for this step 
-Transforming and exposing FAIR (meta)data effectively requires a mix of domain knowledge, semantic expertise and technical skills. Ideally, teams should involve:
-* **Domain experts.** Provide context and ensure that the transformed (meta)data accurately reflects the research content.
-* **Semantic modellers or ontologists.** Advise on selecting and applying the right ontologies, vocabularies and semantic models.
-* **FAIR data stewards or infrastructure professionals.** Coordinate the process and set up the systems needed to store and expose data and metadata in a FAIR-compliant way.
-
-While some basic exposure tasks may not require advanced technical knowledge, setting up robust pipelines (e.g. triplestores, FAIR Data Points) and ensuring semantic interoperability benefits greatly from the combined expertise above.
-
 ## Practical examples from the community
 **VASCA Registry (Castor EDC + FAIR Data Point)**<br>
 The VASCA registry (Registry of Vascular Anomalies) implemented the CDE semantic data model and uses the DCAT metadata schema to publish metadata in three layers: catalogue, dataset and distribution. It stores machine-readable RDF data in Castor EDC’s FAIR Data Point, supporting de novo FAIRification, meaning data is FAIR from the moment it is collected through the eCRF.

--- a/pages/metroline_steps/use_ontologies_in_the_model.md
+++ b/pages/metroline_steps/use_ontologies_in_the_model.md
@@ -86,12 +86,6 @@ Ontologies evolve over time, so mappings must be reviewed and updated to remain 
 
 As the volume of (meta)data and repositories grows, continuous ontology maintenance can become a significant burden. Establish governance rules that clarify which mappings will be maintained, how often they are reviewed and by whom, and make these rules part of your project and repository documentation.
 
-## Expertise requirements for this step
-Experts that may need to be involved, as described in [Metroline Step: Build the Team]({{site.baseurl}}/metroline_steps/build_the_team), are described below. 
-* **Ontology experts.** Select appropriate ontologies, apply alignment patterns and evaluate ontology quality and scope.
-* **Metadata experts.** Ensure coverage of required metadata elements and provide clear documentation for users.
-* **Semantic web technology experts.** Represent the model and its mappings in RDF, OWL and SKOS; maintain model coherence; design persistent IRIs, implement SHACL validation and automate mapping publication workflows.
-
 ## Practical examples from the community 
 * **[CARE-SM (Clinical and Registry Entries Semantic Model)](https://github.com/CARE-SM).** Annotates clinical registry concepts using OBO Foundry-aligned ontologies for precise semantics and cross-resource mapping. Also see this video.
 * **[ELIXIR (European Life-science Infrastructure for Biological Information) Bioschemas](https://bioschemas.org/).** Extends [Schema.org](https://schema.org/) and uses ontology terms to improve dataset discovery on the web. Also see this video.


### PR DESCRIPTION
* Removed "Expertise required" sections from all guidance pages
* Removed references to "Build the team", "Enter data in the eCRF" and "Did you reach your FAIR objectives"