### PR TITLE
External review comments resolved for Organise training

### DIFF
--- a/_data/metroline_steps.yml
+++ b/_data/metroline_steps.yml
@@ -35,11 +35,11 @@
     data_holder: true
     data_user: true
 - id: 4
-  title: Organise Training
+  title: Identify and select training
   summary: This page brings forward the training and educational elements available to guide the team in their journey through the Metroline subsequent steps.
-  url: metroline_steps/organise_training
+  url: metroline_steps/identify_and_select_training
   icon: ":weight_lifting:"
-  status: READY FOR REVIEW
+  status: RELEASED
   keywords:
     - training
     - skills

--- a/_data/sidebars/main.yml
+++ b/_data/sidebars/main.yml
@@ -12,8 +12,8 @@ subitems:
         url: /metroline_steps/define_fairification_objectives
       - title: Have a FAIR data steward on board
         url: /metroline_steps/have_a_fair_data_steward_on_board
-      - title: Organise training
-        url: /metroline_steps/organise_training
+      - title: Identify and select training
+        url: /metroline_steps/identify_and_select_training
       - title: Pre-FAIR assessment
         url: /metroline_steps/pre_fair_assessment
       - title: Creating a FAIR Implementation Profile (FIP)

--- a/pages/metroline_steps/identify_and_select_training.md
+++ b/pages/metroline_steps/identify_and_select_training.md
@@ -1,6 +1,6 @@
 ---
-title: Organise training
-permalink: /metroline_steps/organise_training
+title: Identify and select training
+permalink: /metroline_steps/identify_and_select_training
 ---
 
 {% include glossary_tooltips.html %}
@@ -24,25 +24,25 @@ The journey to making data FAIR is intricate, demanding both a comprehensive und
 
 ## How to
 
-### Step 1 - Consider your roles and/or those of team members
+### Step 1 - Assess training needs
 Before diving into specific training modules, it's beneficial to understand the broader landscape of FAIR training for each specific role in your team. In case your FAIRification project is on existing data you can also consider doing a Pre-FAIR assessment (see [Metroline step: Pre-FAIR Assessment]({{site.baseurl}}/metroline_steps/pre_fair_assessment)). This assessment can help you identify potential knowledge gaps within your team, allowing you to determine appropriate roles and address any training needs. Once you have a clearer picture of the role(s) in your team and you have pinpointed knowledge gaps, you can more effectively suggest and/or select training modules that address specific needs. 
 
 Here are some of the different roles that people have in research projects and FAIRification of data: 
 * **Researchers.** Researchers are responsible for conducting experiments and generating new knowledge. Responsibilities include collecting, cleaning, and analyzing data. Researchers need to have a good understanding of the FAIR principles in order to make sure that their data is accessible, interoperable, and reusable. 
 * **Data stewards.** Data Stewards guide researchers to achieve the FAIR principles and meet funder’s requirements. They need to have a deep understanding of the FAIR principles in order to ensure that data is well-organised and easy to find. Within a research group, Data Stewards are often responsible for managing and curating data. 
-* **Trainer.** If you yourself are the trainer or educator, you will need specific Train-the-Trainer resources. Also, joining other colleagues' training and reviewing their materials can be very helpful to build your expertise. Lastly, any course on education and pedagogy can enrich the content and the dynamics of the training you provide. 
+* **Trainer.** If you yourself are the trainer or educator, you may benefit from attending a specialised Train-the-Trainer course or using Train-the-Trainer resources to strengthen your teaching design and delivery skills. Also, joining other colleagues' training and reviewing their materials can be very helpful to build your expertise. Lastly, any course on education and pedagogy can enrich the content and the dynamics of the training you provide. 
 
 
-### Step 2 - Criteria for selecting appropriate FAIR training
+### Step 2 - Select the appropriate FAIR training
 The next step is to reflect on the requirements, expectations, and resources needed to participate in a particular training. Here are some of the things to consider:
 * **The level of expertise required.** Some training programs are designed for beginners, while others are designed for more experienced professionals. 
 * **The focus of the training.** Some training programs may emphasise technical aspects of FAIRification, while others focus on the policy and legal aspects. Relevant training programs may vary depending on an individual's professional role and career trajectory. 
-* **The format of the training.** Training can be delivered in a variety of formats, including online courses, workshops, and conferences. 
+* **The format of the training.** Training can be delivered in a variety of formats, including online courses, workshops, webinars, hands-on sessions, BYOD and tutorials. 
 * **The time and resources available.** Consider the time you can realistically dedicate as well as practical requirements such as scheduling and registration. While many trainings are free, they may require advance sign-up. 
 
 For more tailored advice, it can be helpful to consult a FAIR training coordinator at your research institute for any training recommendations. If your institute does not have a FAIR training coordinator, you can contact your research support department or your local Digital Competence Center for assistance.
 
-### Step 3 - Where to find the appropriate training
+### Step 3 - Identify training providers and resources
 In addition to identifying which skills are needed, it is also important to know where to look for training, depending on what particular resources you’re looking into. Here we present an overview of where to find certain resources. 
 
 #### Generic FAIR and RDM training


### PR DESCRIPTION
Resolved external review comments for Organise Training, which has been renamed to Identify and select training.