### PR TITLE
Page grouping, guidance filtering, filtering refactoring

### DIFF
--- a/_data/metroline_steps.yml
+++ b/_data/metroline_steps.yml
@@ -16,6 +16,7 @@
   audience:
     data_holder: true
     data_user: true
+  group: Goals & expertise
 - id: 3
   title: Have a FAIR data steward on board
   summary: A FAIR data steward guides teams in organising, storing, and describing data to meet the FAIR principles, ensuring research data can be understood and reused, making science more efficient and transparent.
@@ -34,6 +35,7 @@
   audience:
     data_holder: true
     data_user: true
+  group: Goals & expertise
 - id: 4
   title: Identify and select training
   summary: This page brings forward the training and educational elements available to guide the team in their journey through the Metroline subsequent steps.
@@ -46,10 +48,11 @@
   expertise_required:
     - data steward
     - researcher
-    - Trainer
+    - trainer
   audience:
     data_holder: true
     data_user: true
+  group: Goals & expertise
 - id: 5
   title: Pre-FAIR assessment
   summary: A pre-FAIR assessment evaluates the current state of your data and its alignment with the FAIR principles. Performing this assessment early makes you aware of possibilities for increasing the FAIRness of your data, which in turn increases its impact and ensures its long-term usability.
@@ -65,6 +68,7 @@
   audience:
     data_holder: true
     data_user: true
+  group: Assess & plan
 - id: 6
   title: Design Solution Plan
   summary: This step is about turning the findings from the pre-FAIR assessment into a clear, actionable plan. It means choosing the right tools, deciding who does what, and making sure the process is simple and effective so data can actually become FAIR.
@@ -82,6 +86,7 @@
   audience:
     data_holder: true
     data_user: true
+  group: Assess & plan
 - id: 7
   title: Data access and retrieval
   summary: Before data can be made FAIR, we first need to get it the right way. That means finding trustworthy sources, making sure we’re allowed to use the data, and keeping it safe and private. When we do this properly, it ensures that the data can be trusted, shared, and reused to support new research and innovation.
@@ -99,6 +104,7 @@
   audience:
     data_holder: false
     data_user: true
+  group: Access & reuse
 - id: 8
   title: Assess availability of your metadata
   summary: Metadata describes a resource, like a book’s title and author or a photo’s date and location, which help with organization and discovery of that resource. This Metroline step describes the types of metadata, where you can find them for your resource, and how to improve their quality. Filling metadata gaps enhances a resource’s visibility and reusability.
@@ -115,6 +121,7 @@
   audience:
     data_holder: true
     data_user: true
+  group: Assess & plan
 - id: 9
   title: Select Identifier Scheme
   summary: In simple terms, selecting an identifier scheme is like deciding how to label books in a library. If every book has a clear catalogue number, author, and subject, readers can always find what they need. Without a consistent scheme, books would be scattered and confusing. For datasets, choosing the right identifier scheme ensures that your data can be discovered, cited and reused. Similar to well-organised books that are easy to find in a structured library.
@@ -130,6 +137,7 @@
   audience:
     data_holder: true
     data_user: true
+  group: Assess & plan
 - id: 10
   title: Register resource level metadata
   summary: To make your resource (e.g. data), available for reuse, its metadata can be published in a catalogue. This step helps you find a catalogue where you can register these resource metadata and explains why adding your resource to such a catalogue is important.
@@ -147,6 +155,7 @@
   audience:
     data_holder: true
     data_user: false
+  group: Register & expose
 - id: 11
   title: Register structural metadata
   summary: Structural metadata can describe many aspects of how data is organised, represented and related within a dataset or resource. In this step, the focus is primarily on structural metadata describing data elements, their definitions and formats, such as codebooks or data dictionaries. Publishing structural metadata helps others understand, find and reuse your data more easily. This step also describes approaches for making structural metadata easier for computers to process automatically, which can support specific FAIRification objectives.
@@ -163,6 +172,7 @@
   audience:
     data_holder: true
     data_user: false
+  group: Register & expose
 - id: 12
   title: Apply common data elements
   summary: Common data elements (CDEs) are standardised data elements, such as variables and measurements, paired with defined rules for how values should be recorded. They are developed to promote consistency and reuse in data collection across different settings, enabling seamless integration and comparison. This step encourages you to search for relevant CDEs and offers guidance on what to do if no suitable CDE is available.
@@ -179,6 +189,7 @@
   audience:
     data_holder: true
     data_user: true
+  group: Data definition
 - id: 13
   title: Analyse data semantics
   summary: In this step, the aim is to gain more insight into the existing data, or the data that you aim to collect. Clearly defining the meaning (semantics) of the data is an important step for creating the semantic model, as well as for data collection via, for example, electronic case report forms (eCRFs).
@@ -195,6 +206,7 @@
   audience:
     data_holder: true
     data_user: true
+  group: Data definition
 - id: 14
   title: Design eCRF (data collection)
   summary: >
@@ -213,6 +225,7 @@
   audience:
     data_holder: true
     data_user: false
+  group: Data definition
 - id: 15
   title: Create or reuse a semantic (meta)data model
   summary: Creating a semantic (meta)data model often requires considerable effort as it is a complex task. Reusing an existing model, where possible, can save time and increase interoperability. Start by checking if a suitable model already exists. If not, follow a structured approach to create one. Once the model is in place, share it using common platforms and provide clear documentation to support reuse by others.
@@ -227,6 +240,7 @@
   audience:
     data_holder: true
     data_user: true
+  group: Semantic modeling
 - id: 16
   title: Use ontologies in the model
   summary: This process involves linking your semantic (meta)data model to ontologies, which are formal, shared vocabularies that provide precise, machine-readable definitions for concepts. This step is written for a broad FAIRification audience and may be used by researchers, data stewards, metadata specialists and ontology or semantic web technology experts, depending on the project context. Not all activities need to be carried out by the same person. researchers and project teams can use this step to understand the process and provide domain knowledge, while specialist support may be needed for ontology selection, concept mapping, formal representation, validation and maintenance. By assigning standard definitions to the elements in your model, you make their meanings explicit and unambiguous. This allows different computer systems to correctly understand, combine and compare data from various sources consistently, making the data more interoperable and easier to reuse across projects.
@@ -242,6 +256,7 @@
   audience:
     data_holder: true
     data_user: true
+  group: Semantic modeling
 - id: 17
   title: Obtain informed consent
   summary: To ensure your data and materials can be reused in the future, your subject information sheet (SIS) and informed consent form (ICF) must address reuse. This Metroline step provides consideration and resources for preparing your SIS and ICF.
@@ -257,6 +272,7 @@
   audience:
     data_holder: true
     data_user: false
+  group: Access & reuse
 - id: 19
   title: Apply (meta)data model
   summary: Think of your data like a book in a library. A metadata model defines the kind of information included in the catalogue entry, such as the title, author, topic, and publication date, helping people find and understand the book. A data model defines how the contents of the book are organised and related, like the structure of chapters, sections, and references. Using both makes it easier for people and machines to find, understand, and reuse your data.
@@ -275,6 +291,7 @@
   audience:
     data_holder: true
     data_user: false
+  group: Semantic modeling
 - id: 20
   title: Transform and expose FAIR (meta)data
   summary: Think of your data like a well-written book that’s hidden away on a shelf that no one knows about. By transforming it into a standardised, machine-readable format and publishing it through trusted channels, you place it in a public library where everyone, people and machines, can easily find, open, and read it.
@@ -293,6 +310,7 @@
   audience:
     data_holder: true
     data_user: false
+  group: Register & expose
 - id: 21
   title: Define access conditions
   summary: When making health care data FAIR, data holders have to keep the balance between making data accessible for reuse and protecting personal information of subjects present in the data. This Metroline step helps you pick the appropriate access level to your data and publish the necessary information in the metadata.
@@ -304,13 +322,14 @@
     - legal
     - governance
   expertise_required:
-    - Data curator
+    - data curator
     - data steward
     - ELSI expert
     - researcher
   audience:
     data_holder: true
     data_user: false
+  group: Access & reuse
 - id: 22
   title: Query (use) over resources
   summary: Querying FAIR resources is the process of asking structured questions to retrieve data that is easy to find, access, and reuse. When resources follow FAIR principles, queries become more efficient because the data is well-organized and clearly described. In this step, we will explore the tools and platforms that enable effective querying of FAIR-compliant resources.
@@ -326,6 +345,7 @@
   audience:
     data_holder: false
     data_user: true
+  group: Use & evaluate
 - id: 23
   title: Assess FAIRness
   summary: Now that you’ve FAIRified your data, it’s time to check the resulting FAIRness and decide if you’ve reached your goals. Use tools and other methods to assess if your data is truly Findable, Accessible, Interoperable, and Reusable. If needed, adjust or improve things so your data stays FAIR in the long run.
@@ -342,6 +362,7 @@
   audience:
     data_holder: true
     data_user: true
+  group: Use & evaluate
 - id: 25
   title: Creating a FAIR Implementation Profile (FIP)
   summary: A FAIR Implementation Profile (FIP) describes the practical choices a community makes to apply the FAIR data principles using shared standards and tools. It lists the specific resources, such as metadata schemas, ontologies and licences, that make data findable, accessible, interoperable and reusable. Other communities can reuse these profiles to align their practices, fill gaps and improve collaboration.
@@ -359,4 +380,4 @@
   audience:
     data_holder: true
     data_user: true
-
+  group: Assess & plan

--- a/_data/sidebars/main.yml
+++ b/_data/sidebars/main.yml
@@ -8,49 +8,19 @@ subitems:
   - title: FAIR steps
     url: /fair_metroline_steps
     subitems:
-      - title: Define FAIRification objectives
-        url: /metroline_steps/define_fairification_objectives
-      - title: Have a FAIR data steward on board
-        url: /metroline_steps/have_a_fair_data_steward_on_board
-      - title: Identify and select training
-        url: /metroline_steps/identify_and_select_training
-      - title: Pre-FAIR assessment
-        url: /metroline_steps/pre_fair_assessment
-      - title: Creating a FAIR Implementation Profile (FIP)
-        url: /metroline_steps/creating_a_fair_implementation_profile
-      - title: Design solution plan
-        url: /metroline_steps/design_solution_plan
-      - title: Data access and retrieval
-        url: /metroline_steps/data_access_and_retrieval
-      - title: Assess availability of your metadata
-        url: /metroline_steps/assess_availability_of_your_metadata
-      - title: Select identifier scheme
-        url: /metroline_steps/select_identifier_scheme
-      - title: Register resource-level metadata
-        url: /metroline_steps/register_resource_level_metadata
-      - title: Register structural metadata
-        url: /metroline_steps/register_structural_metadata
-      - title: Apply common data elements
-        url: /metroline_steps/apply_common_data_elements
-      - title: Analyse data semantics
-        url: /metroline_steps/analyse_data_semantics
-      - title: Design eCRF
-        url: /metroline_steps/design_ecrf
-      - title: Create or reuse a semantic (meta)data model
-        url: /metroline_steps/create_or_reuse_a_semantic_model
-      - title: Use ontologies in the model
-        url: /metroline_steps/use_ontologies_in_the_model
-      - title: Obtain informed consent
-        url: /metroline_steps/obtain_informed_consent
-      - title: Apply (meta)data model
-        url: /metroline_steps/apply_metadata_model
-      - title: Transform and expose FAIR (meta)data
-        url: /metroline_steps/transform_and_expose_fair_metadata
-      - title: Define access conditions
-        url: /metroline_steps/define_access_conditions
-      - title: Query (use) over resources
-        url: /metroline_steps/query_over_resources
-      - title: Assess FAIRness
-        url: /metroline_steps/assess_fairness
+      - title: Goals & expertise
+        url: /fair_metroline_steps?group=goals-expertise
+      - title: Assess & plan
+        url: /fair_metroline_steps?group=assess-plan
+      - title: Access & reuse
+        url: /fair_metroline_steps?group=access-reuse
+      - title: Data definition
+        url: /fair_metroline_steps?group=data-definition
+      - title: Semantic modeling
+        url: /fair_metroline_steps?group=semantic-modeling
+      - title: Register & expose
+        url: /fair_metroline_steps?group=register-expose
+      - title: Use & evaluate
+        url: /fair_metroline_steps?group=use-evaluate
   - title: Glossary
     url: /glossary

--- a/_includes/toolassemblies/navigation-card.html
+++ b/_includes/toolassemblies/navigation-card.html
@@ -1,0 +1,42 @@
+{%- if include.aria_label %}
+{%- assign card_aria_label = include.aria_label %}
+{%- else %}
+{%- assign card_aria_label = include.title | prepend: "Go to the " | append: " page" %}
+{%- endif %}
+<a href="{{ include.url | relative_url }}" class="card h-100 tool-card" aria-label="{{ card_aria_label }}">
+    <div class="card-body">
+
+        {%- if include.image %}
+        {%- if include.image contains "http://" or include.image contains "https://" %}
+        {%- assign file_url = include.image -%}
+        {%- else %}
+        {%- capture file_url -%}
+        {{ "/assets/img/" | append: include.image | relative_url }}
+        {%- endcapture -%}
+        {%- endif %}
+        <div class="tool-card-icon">
+            <img
+                alt="logo of {{ include.title }}"
+                src="{{ file_url }}"
+            >
+        </div>
+        {%- elsif include.icon %}
+        <div class="tool-card-icon {{ include.icon_class }}" aria-hidden="true">
+            <span>{{ include.icon }}</span>
+        </div>
+        {%- endif %}
+
+        <h3 class="tool-card-title">{{ include.title }}</h3>
+
+        {%- if include.description %}
+        <p class="tool-card-description">{{ include.description }}</p>
+        {%- endif %}
+
+        {%- if include.meta %}
+        <div class="tool-card-meta">
+            {{ include.meta }}
+        </div>
+        {%- endif %}
+
+    </div>
+</a>

--- a/_includes/toolassemblies/search-tiles.html
+++ b/_includes/toolassemblies/search-tiles.html
@@ -40,62 +40,19 @@
 {%- assign allinstitutes = allinstitutes | split: ", " | uniq | sort %}
 <div class="row g-4 row-cols-1 row-cols-md-2 row-cols-lg-{{ include.col | default: 2 }} my-4">
     {%- if include.domains == true %}
-    <div class="col">
-        <div class="input-group">
-            <label class="input-group-text" for="domains-input">Filter by domain</label>
-            <select class="form-select" id="domains-input" aria-label="Filter by domain">
-                <option value="">All domains</option>
-                {%- for domain in alldomains %}
-                {%- if domain != "" %}
-                <option value="{{domain | slugify}}">{{domain}}</option>
-                {%- endif %}
-                {%- endfor %}
-            </select>
-            <button class="btn btn-primary" title="Button to clear domains selection" type="button" id="cleardomainfilter">
-                <i class="fa-solid fa-backspace"></i>
-            </button>
-        </div>
-    </div>
+    {% include toolassemblies/tile-filter-select.html id="domains-input" key="domains" param="domain" label="Filter by domain" all_label="All domains" clear_label="domains" options=alldomains %}
     {%- endif %}
     {%- if include.phases == true %}
-    <div class="col">
-        <div class="input-group">
-            <label class="input-group-text" for="phases-input">Filter by phase</label>
-            <select class="form-select" id="phases-input" aria-label="Filter by phase">
-                <option value="">All phases</option>
-                {%- for phase in allphases %}
-                <option value="{{phase | slugify}}">{{phase}}</option>
-                {%- endfor %}
-            </select>
-            <button class="btn btn-primary" title="Button to clear phases selection" type="button" id="clearphasefilter">
-                <i class="fa-solid fa-backspace"></i>
-            </button>
-        </div>
-    </div>
+    {% include toolassemblies/tile-filter-select.html id="phases-input" key="phases" param="phase" label="Filter by phase" all_label="All phases" clear_label="phases" options=allphases %}
     {%- endif %}
     {%- if include.institutes == true %}
-    <div class="col">
-        <div class="input-group">
-            <label class="input-group-text" for="institutes-input">Filter by institute</label>
-            <select class="form-select" id="institutes-input" aria-label="Filter by institute">
-                <option value="">All institutes</option>
-                {%- for institute in allinstitutes %}
-                {%- if institute != "" %}
-                <option value="{{institute | slugify}}">{{institute}}</option>
-                {%- endif %}
-                {%- endfor %}
-            </select>
-            <button class="btn btn-primary" title="Button to clear institutes selection" type="button" id="clearinstitutefilter">
-                <i class="fa-solid fa-backspace"></i>
-            </button>
-        </div>
-    </div>
+    {% include toolassemblies/tile-filter-select.html id="institutes-input" key="institutes" param="institute" label="Filter by institute" all_label="All institutes" clear_label="institutes" options=allinstitutes %}
     {%- endif %}
     {%- if include.search == true %}
     <div class="col">
         <div class="input-group">
             <span class="input-group-text" id="search-label-tiles"><i class="fa-solid fa-magnifying-glass"></i></span>
-            <input type="text" id="title-search" class="form-control" onkeyup="applyFilters();" placeholder="Search titles and descriptions..." aria-label="{{page.type | replace: '_', ' ' |}}" aria-describedby="search-label-tiles">
+            <input type="text" id="title-search" class="form-control tile-search-control" onkeyup="applyTileFilters();" placeholder="Search titles and descriptions..." aria-label="Search titles and descriptions" aria-describedby="search-label-tiles">
             <button class="btn btn-primary" title="Button to clear search" type="button" id="clearsearch">
                 <i class="fa-solid fa-backspace"></i>
             </button>
@@ -124,235 +81,35 @@
     {%- else %}
     {%- assign current_page = related_page %}
     {%- endif %}
-    {%- assign domains_classes = "" %}
-    {%- assign phases_classes = "" %}
-    {%- assign institutes_classes = "" %}
     {%- assign except = include.except | split: ", " %}
     {%- if current_page.title and current_page.search_exclude != true %}
     {%- unless except contains current_page.name %}
+    {%- capture domains_classes -%}{%- for domain in current_page.domain %}{{ domain | slugify }} {% endfor -%}{%- endcapture -%}
+    {%- capture phases_classes -%}{%- for phase in current_page.phase %}{{ phase | slugify }} {% endfor -%}{%- endcapture -%}
+    {%- capture institutes_classes -%}{%- for institute in current_page.institutes %}{{ institute | slugify }} {% endfor -%}{%- endcapture -%}
+<div class="col" data-domains="{{ domains_classes | strip }}" data-phases="{{ phases_classes | strip }}" data-institutes="{{ institutes_classes | strip }}">
+    {%- assign pagedomains = "" | split: "" %}
     {%- if current_page.domain %}
-    {%- capture domains_classes -%}
-    {%- assign domains_output = "" %}
-    {%- for domain in current_page.domain %}
-    {%- assign group_domains = domain | slugify | prepend: " " %}
-    {%- assign domains_output = domains_output | append: group_domains | strip %}
-    {%- endfor %}{{domains_output}}
-    {%- endcapture -%}
+    {%- assign pagedomains = current_page.domain | sort %}
     {%- endif %}
-    {%- if current_page.phase %}
-    {%- capture phases_classes -%}
-    {%- assign phases_output = "" %}
-    {%- for phase in current_page.phase %}
-    {%- assign group_phases = phase | slugify | prepend: " " %}
-    {%- assign phases_output = phases_output | append: group_phases | strip %}
-    {%- endfor %}{{phases_output}}
-    {%- endcapture -%}
-    {%- endif %}
-    {%- if current_page.institutes %}
-    {%- capture institutes_classes -%}
-    {%- assign institutes_output = "" %}
-    {%- for institute in current_page.institutes %}
-    {%- assign group_institutes = institute | slugify | prepend: " " %}
-    {%- assign institutes_output = institutes_output | append: group_institutes | strip %}
-    {%- endfor %}{{institutes_output}}
-    {%- endcapture -%}
-    {%- endif %}
-<div class="col" data-domains="{{domains_classes}}" data-phases="{{phases_classes}}" data-institutes="{{institutes_classes}}">
-    <a href="{{ current_page.url | relative_url }}" class="card h-100 tool-card" aria-label="Go to the {{ current_page.title }} page">
-        <div class="card-body">
-
-            {%- if current_page.page_img %}
-            {%- if current_page.page_img contains "http://" or current_page.page_img contains "https://" %}
-            {%- assign file_url = current_page.page_img -%}
-            {%- else %}
-            {%- capture file_url -%}
-            {{ "/assets/img/" | append: current_page.page_img | relative_url }}
-            {%- endcapture -%}
-            {%- endif %}
-            <div class="tool-card-icon">
-                <img
-                    alt="logo of {{ current_page.title }}"
-                    src="{{ file_url }}"
-                >
-            </div>
-            {%- endif %}
-
-            <h3 class="tool-card-title">{{ current_page.title }}</h3>
-
-            {%- if current_page.description %}
-            <p class="tool-card-description">{{ current_page.description }}</p>
-            {%- endif %}
-
-            <div class="tool-card-meta">
-                {%- if current_page.domain %}
-                {%- assign pagedomains = current_page.domain | sort %}
-                <div class="tool-tags-group">
-                    <span class="tool-tags-label">Domains:</span>
-                    <div class="tool-tags">
-                        {%- for domain in pagedomains %}
-                        <span class="badge bg-primary">{{ domain }}</span>
-                        {%- endfor %}
-                    </div>
-                </div>
-                {%- endif %}
-
-                {%- if current_page.phase %}
-                {%- assign pagephases = current_page.phase %}
-                <div class="tool-tags-group">
-                    <span class="tool-tags-label">Phases:</span>
-                    <div class="tool-tags">
-                        {%- for phase in pagephases %}
-                        <span class="badge bg-secondary">{{ phase }}</span>
-                        {%- endfor %}
-                    </div>
-                </div>
-                {%- endif %}
-            </div>
-
-        </div>
-    </a>
+    {%- capture card_meta %}
+        {%- include toolassemblies/tag-group.html label="Domains" values=pagedomains badge="bg-primary" %}
+        {%- include toolassemblies/tag-group.html label="Phases" values=current_page.phase badge="bg-secondary" %}
+    {%- endcapture %}
+    {%- assign card_meta = card_meta | strip %}
+    {%- include toolassemblies/navigation-card.html
+        url=current_page.url
+        title=current_page.title
+        description=current_page.description
+        image=current_page.page_img
+        meta=card_meta
+    %}
 </div>
 {% endunless %}
 {%- endif %}
 {%- endfor %}
 </div>
 
-
 {%- if include.domains == true or include.phases == true or include.institutes == true or include.search == true %}
-<script type="text/javascript">
-    /**
-     * Apply all active filters
-     */
-    function applyFilters() {
-        const cols = document.querySelectorAll(".navigation-tiles .col");
-        const domainSelect = document.getElementById('domains-input');
-        const phaseSelect = document.getElementById('phases-input');
-        const instituteSelect = document.getElementById('institutes-input');
-        const searchInput = document.getElementById('title-search');
-
-        const selectedDomain = domainSelect ? domainSelect.value : '';
-        const selectedPhase = phaseSelect ? phaseSelect.value : '';
-        const selectedInstitute = instituteSelect ? instituteSelect.value : '';
-        const searchFilter = searchInput ? searchInput.value.toLowerCase() : '';
-
-        for (col of cols) {
-            const colDomains = col.getAttribute("data-domains") ? col.getAttribute("data-domains").split(" ") : [];
-            const colPhases = col.getAttribute("data-phases") ? col.getAttribute("data-phases").split(" ") : [];
-            const colInstitutes = col.getAttribute("data-institutes") ? col.getAttribute("data-institutes").split(" ") : [];
-
-            const domainMatch = !selectedDomain || colDomains.indexOf(selectedDomain) !== -1;
-            const phaseMatch = !selectedPhase || colPhases.indexOf(selectedPhase) !== -1;
-            const instituteMatch = !selectedInstitute || colInstitutes.indexOf(selectedInstitute) !== -1;
-            const body = col.querySelector(".card-body");
-            const searchMatch = !searchFilter || (body && body.innerText.toLowerCase().indexOf(searchFilter) > -1);
-
-            if (domainMatch && phaseMatch && instituteMatch && searchMatch) {
-                col.classList.remove("d-none");
-            } else {
-                col.classList.add("d-none");
-            }
-        }
-
-        // Update URL with current filter values
-        const params = new URLSearchParams();
-        if (selectedDomain) params.set('domain', selectedDomain);
-        if (selectedPhase) params.set('phase', selectedPhase);
-        if (selectedInstitute) params.set('institute', selectedInstitute);
-        const newUrl = params.toString() ? `?${params}` : location.pathname;
-        history.replaceState({}, '', newUrl);
-    }
-
-    $(document).ready(function () {
-        var domains = document.getElementById('domains-input');
-        if (domains) {
-            domains.addEventListener("change", applyFilters);
-        }
-
-        var phases = document.getElementById('phases-input');
-        if (phases) {
-            phases.addEventListener("change", applyFilters);
-        }
-
-        var institutes = document.getElementById('institutes-input');
-        if (institutes) {
-            institutes.addEventListener("change", applyFilters);
-        }
-
-        var cleardomains = document.getElementById("cleardomainfilter");
-        if (cleardomains) {
-            cleardomains.addEventListener("click", function () {
-                var domains = document.getElementById('domains-input');
-                if (domains) {
-                    domains.selectedIndex = -1;
-                    applyFilters();
-                }
-            });
-        }
-
-        var clearphases = document.getElementById("clearphasefilter");
-        if (clearphases) {
-            clearphases.addEventListener("click", function () {
-                var phases = document.getElementById('phases-input');
-                if (phases) {
-                    phases.selectedIndex = -1;
-                    applyFilters();
-                }
-            });
-        }
-
-        var clearinstitutes = document.getElementById("clearinstitutefilter");
-        if (clearinstitutes) {
-            clearinstitutes.addEventListener("click", function () {
-                var institutes = document.getElementById('institutes-input');
-                if (institutes) {
-                    institutes.selectedIndex = -1;
-                    applyFilters();
-                }
-            });
-        }
-    });
-
-    $(document).ready(function () {
-        var clearsearch = document.getElementById("clearsearch");
-        if (clearsearch) {
-            clearsearch.addEventListener("click", function () {
-                var search = document.getElementById('title-search')
-                if (search) {
-                    search.value = ''
-                    applyFilters();
-                }
-            });
-        }
-
-        // Read URL parameters and apply filters on page load
-        const urlParams = new URLSearchParams(window.location.search);
-        const urlDomain = urlParams.get('domain');
-        const urlPhase = urlParams.get('phase');
-        const urlInstitute = urlParams.get('institute');
-
-        if (urlDomain) {
-            const domainSelect = document.getElementById('domains-input');
-            if (domainSelect) {
-                domainSelect.value = urlDomain;
-            }
-        }
-        if (urlPhase) {
-            const phaseSelect = document.getElementById('phases-input');
-            if (phaseSelect) {
-                phaseSelect.value = urlPhase;
-            }
-        }
-        if (urlInstitute) {
-            const instituteSelect = document.getElementById('institutes-input');
-            if (instituteSelect) {
-                instituteSelect.value = urlInstitute;
-            }
-        }
-
-        // Apply filters if any URL parameters were present
-        if (urlDomain || urlPhase || urlInstitute) {
-            applyFilters();
-        }
-    });
-</script>
+{% include toolassemblies/tile-filters-script.html %}
 {%- endif %}

--- a/_includes/toolassemblies/tag-group.html
+++ b/_includes/toolassemblies/tag-group.html
@@ -1,0 +1,10 @@
+{%- if include.values %}
+<div class="tool-tags-group">
+    <span class="tool-tags-label">{{ include.label }}:</span>
+    <div class="tool-tags">
+        {%- for tag in include.values %}
+        <span class="badge {{ include.badge | default: 'bg-primary' }}">{{ tag }}</span>
+        {%- endfor %}
+    </div>
+</div>
+{%- endif %}

--- a/_includes/toolassemblies/tile-filter-select.html
+++ b/_includes/toolassemblies/tile-filter-select.html
@@ -1,0 +1,16 @@
+<div class="col">
+    <div class="input-group">
+        <label class="input-group-text" for="{{ include.id }}">{{ include.label }}</label>
+        <select class="form-select tile-filter-control" id="{{ include.id }}" aria-label="{{ include.label }}" data-filter-key="{{ include.key }}" data-query-param="{{ include.param | default: include.key }}">
+            <option value="">{{ include.all_label }}</option>
+            {%- for option in include.options %}
+            {%- if option != "" %}
+            <option value="{{ option | slugify }}">{{ option }}</option>
+            {%- endif %}
+            {%- endfor %}
+        </select>
+        <button class="btn btn-primary tile-filter-clear" title="Button to clear {{ include.clear_label | default: include.key }} selection" type="button" data-target="{{ include.id }}">
+            <i class="fa-solid fa-backspace"></i>
+        </button>
+    </div>
+</div>

--- a/_includes/toolassemblies/tile-filters-script.html
+++ b/_includes/toolassemblies/tile-filters-script.html
@@ -1,0 +1,86 @@
+<script type="text/javascript">
+    function applyTileFilters() {
+        const tiles = document.querySelectorAll(".navigation-tiles .col");
+        const filters = document.querySelectorAll(".tile-filter-control");
+        const searchInput = document.querySelector(".tile-search-control");
+        const searchFilter = searchInput ? searchInput.value.toLowerCase() : "";
+
+        for (const tile of tiles) {
+            let filterMatch = true;
+
+            for (const filter of filters) {
+                const selectedValue = filter.value;
+                if (!selectedValue) continue;
+
+                const filterKey = filter.getAttribute("data-filter-key");
+                const tileValues = tile.getAttribute(`data-${filterKey}`) || "";
+                const values = tileValues.split(" ").filter(Boolean);
+                if (values.indexOf(selectedValue) === -1) {
+                    filterMatch = false;
+                    break;
+                }
+            }
+
+            const body = tile.querySelector(".card-body");
+            const searchMatch = !searchFilter || (body && body.innerText.toLowerCase().indexOf(searchFilter) > -1);
+
+            if (filterMatch && searchMatch) {
+                tile.classList.remove("d-none");
+            } else {
+                tile.classList.add("d-none");
+            }
+        }
+
+        const params = new URLSearchParams();
+        for (const filter of filters) {
+            const queryParam = filter.getAttribute("data-query-param");
+            if (filter.value) params.set(queryParam, filter.value);
+        }
+        const newUrl = params.toString() ? `?${params}` : location.pathname;
+        history.replaceState({}, "", newUrl);
+    }
+
+    $(document).ready(function () {
+        const filters = document.querySelectorAll(".tile-filter-control");
+        for (const filter of filters) {
+            filter.addEventListener("change", applyTileFilters);
+        }
+
+        const clearButtons = document.querySelectorAll(".tile-filter-clear");
+        for (const clearButton of clearButtons) {
+            clearButton.addEventListener("click", function () {
+                const target = document.getElementById(clearButton.getAttribute("data-target"));
+                if (target) {
+                    target.value = "";
+                    applyTileFilters();
+                }
+            });
+        }
+
+        const clearSearch = document.getElementById("clearsearch");
+        if (clearSearch) {
+            clearSearch.addEventListener("click", function () {
+                const search = document.querySelector(".tile-search-control");
+                if (search) {
+                    search.value = "";
+                    applyTileFilters();
+                }
+            });
+        }
+
+        const urlParams = new URLSearchParams(window.location.search);
+        let hasUrlFilters = false;
+        for (const filter of filters) {
+            const queryParam = filter.getAttribute("data-query-param");
+            const urlValue = urlParams.get(queryParam);
+            if (urlValue) {
+                filter.value = urlValue;
+                hasUrlFilters = true;
+            }
+        }
+
+        if (hasUrlFilters) {
+            applyTileFilters();
+        }
+    });
+</script>

--- a/pages/fair_metroline_steps.md
+++ b/pages/fair_metroline_steps.md
@@ -1,7 +1,6 @@
 ---
 title: FAIR Metroline steps
 ---
-
 {% assign allkeywords = "" %}
 {% assign allexpertise = "" %}
 {% assign allgroups = "" %}
@@ -33,134 +32,46 @@ title: FAIR Metroline steps
 {% assign allkeywords = allkeywords | split: ", " | uniq | sort_natural %}
 {% assign allexpertise = allexpertise | split: ", " | uniq | sort_natural %}
 {% assign allgroups = allgroups | split: ", " | uniq %}
+{% assign audience_options = "Data holder|Data user" | split: "|" %}
 
 <div class="row g-4 row-cols-1 row-cols-md-2 my-4">
-    <div class="col">
-    <div class="input-group">
-      <label class="input-group-text" for="group-input">Filter by group</label>
-      <select class="form-select" id="group-input" aria-label="Filter by group">
-        <option value="">All groups</option>
-        {% for group in allgroups %}
-          {% if group != "" %}
-            <option value="{{ group | slugify }}">{{ group }}</option>
-          {% endif %}
-        {% endfor %}
-      </select>
-      <button class="btn btn-primary" title="Button to clear group selection" type="button" id="cleargroupfilter">
-        <i class="fa-solid fa-backspace"></i>
-      </button>
-    </div>
-  </div>
-  <div class="col">
-    <div class="input-group">
-      <label class="input-group-text" for="keywords-input">Filter by keyword</label>
-      <select class="form-select" id="keywords-input" aria-label="Filter by keyword">
-        <option value="">All keywords</option>
-        {% for keyword in allkeywords %}
-          {% if keyword != "" %}
-            <option value="{{ keyword | slugify }}">{{ keyword }}</option>
-          {% endif %}
-        {% endfor %}
-      </select>
-      <button class="btn btn-primary" title="Button to clear keyword selection" type="button" id="clearkeywordfilter">
-        <i class="fa-solid fa-backspace"></i>
-      </button>
-    </div>
-  </div>
-  <div class="col">
-    <div class="input-group">
-      <label class="input-group-text" for="expertise-input">Filter by expertise</label>
-      <select class="form-select" id="expertise-input" aria-label="Filter by expertise">
-        <option value="">All expertise</option>
-        {% for expertise in allexpertise %}
-          {% if expertise != "" %}
-            <option value="{{ expertise | slugify }}">{{ expertise }}</option>
-          {% endif %}
-        {% endfor %}
-      </select>
-      <button class="btn btn-primary" title="Button to clear expertise selection" type="button" id="clearexpertisefilter">
-        <i class="fa-solid fa-backspace"></i>
-      </button>
-    </div>
-  </div>
-  <div class="col">
-    <div class="input-group">
-      <label class="input-group-text" for="audience-input">Filter by audience</label>
-      <select class="form-select" id="audience-input" aria-label="Filter by audience">
-        <option value="">All audiences</option>
-        <option value="data-holder">Data holder</option>
-        <option value="data-user">Data user</option>
-      </select>
-      <button class="btn btn-primary" title="Button to clear audience selection" type="button" id="clearaudiencefilter">
-        <i class="fa-solid fa-backspace"></i>
-      </button>
-    </div>
-  </div>
+  {% include toolassemblies/tile-filter-select.html id="group-input" key="group" label="Filter by group" all_label="All groups" clear_label="group" options=allgroups %}
+  {% include toolassemblies/tile-filter-select.html id="keywords-input" key="keywords" param="keyword" label="Filter by keyword" all_label="All keywords" clear_label="keyword" options=allkeywords %}
+  {% include toolassemblies/tile-filter-select.html id="expertise-input" key="expertise" label="Filter by expertise" all_label="All expertise" clear_label="expertise" options=allexpertise %}
+  {% include toolassemblies/tile-filter-select.html id="audience-input" key="audience" label="Filter by audience" all_label="All audiences" clear_label="audience" options=audience_options %}
 </div>
 
 <div class="steps row row-cols-1 row-cols-md-2 g-4 mb-5 navigation-tiles">
 {% for step in site.data.metroline_steps %}
-  {% capture keyword_classes %}{% for keyword in step.keywords %};{{ keyword | slugify }}{% endfor %};{% endcapture %}
-  {% capture expertise_classes %}{% for expertise in step.expertise_required %};{{ expertise | slugify }}{% endfor %};{% endcapture %}
-  {% capture audience_classes %}{% if step.audience.data_holder %};data-holder{% endif %}{% if step.audience.data_user %};data-user{% endif %};{% endcapture %}
-  <div class="col step" data-keywords="{{ keyword_classes | strip }}" data-expertise="{{ expertise_classes | strip }}" data-audience="{{ audience_classes | strip }}" data-group=";{{ step.group | slugify }};">
-    <a href="{{ site.baseurl }}/{{ step.url }}" class="card h-100 tool-card" aria-label="Go to the {{ step.title }} page">
-      <div class="card-body">
-        <div class="tool-card-icon step-card-icon" aria-hidden="true">
-          <span>{{ step.icon }}</span>
-        </div>
-
-        <h3 class="tool-card-title">{{ step.title }}</h3>
-        <p class="tool-card-description">{{ step.summary }}</p>
-
-        <div class="tool-card-meta">
-          {% if step.keywords %}
-            <div class="tool-tags-group">
-              <span class="tool-tags-label">Keywords:</span>
-              <div class="tool-tags">
-                {% for keyword in step.keywords %}
-                  <span class="badge bg-primary">{{ keyword }}</span>
-                {% endfor %}
-              </div>
-            </div>
-          {% endif %}
-
-          {% if step.expertise_required %}
-            <div class="tool-tags-group">
-              <span class="tool-tags-label">Expertise:</span>
-              <div class="tool-tags">
-                {% for expertise in step.expertise_required %}
-                  <span class="badge bg-secondary">{{ expertise }}</span>
-                {% endfor %}
-              </div>
-            </div>
-          {% endif %}
-
-          {% if step.audience %}
-            <div class="tool-tags-group">
-              <span class="tool-tags-label">Audience:</span>
-              <div class="tool-tags">
-                {% if step.audience.data_holder %}
-                  <span class="badge bg-primary">Data holder</span>
-                {% endif %}
-                {% if step.audience.data_user %}
-                  <span class="badge bg-primary">Data user</span>
-                {% endif %}
-              </div>
-            </div>
-          {% endif %}
-
-          {% if step.group %}
-            <div class="tool-tags-group">
-              <span class="tool-tags-label">Group:</span>
-              <div class="tool-tags">
-                <span class="badge bg-secondary">{{ step.group }}</span>
-              </div>
-            </div>
-          {% endif %}
-        </div>
-      </div>
-    </a>
+  {% capture keyword_classes %}{% for keyword in step.keywords %}{{ keyword | slugify }} {% endfor %}{% endcapture %}
+  {% capture expertise_classes %}{% for expertise in step.expertise_required %}{{ expertise | slugify }} {% endfor %}{% endcapture %}
+  {% capture audience_classes %}{% if step.audience.data_holder %}data-holder {% endif %}{% if step.audience.data_user %}data-user {% endif %}{% endcapture %}
+  {% capture group_class %}{{ step.group | slugify }}{% endcapture %}
+  {% assign audience_tags = "" | split: "" %}
+  {% if step.audience.data_holder and step.audience.data_user %}
+    {% assign audience_tags = "Data holder|Data user" | split: "|" %}
+  {% elsif step.audience.data_holder %}
+    {% assign audience_tags = "Data holder" | split: "|" %}
+  {% elsif step.audience.data_user %}
+    {% assign audience_tags = "Data user" | split: "|" %}
+  {% endif %}
+  {% assign group_tags = step.group | split: "|" %}
+  <div class="col step" data-keywords="{{ keyword_classes | strip }}" data-expertise="{{ expertise_classes | strip }}" data-audience="{{ audience_classes | strip }}" data-group="{{ group_class | strip }}">
+    {% capture card_meta %}
+      {% include toolassemblies/tag-group.html label="Keywords" values=step.keywords badge="bg-primary" %}
+      {% include toolassemblies/tag-group.html label="Expertise" values=step.expertise_required badge="bg-secondary" %}
+      {% include toolassemblies/tag-group.html label="Audience" values=audience_tags badge="bg-primary" %}
+      {% include toolassemblies/tag-group.html label="Group" values=group_tags badge="bg-secondary" %}
+    {% endcapture %}
+    {% assign card_meta = card_meta | strip %}
+    {% include toolassemblies/navigation-card.html
+      url=step.url
+      title=step.title
+      description=step.summary
+      icon=step.icon
+      icon_class="step-card-icon"
+      meta=card_meta
+    %}
   </div>
 {% endfor %}
 </div>
@@ -176,135 +87,4 @@ title: FAIR Metroline steps
   }
 </style>
 
-<script type="text/javascript">
-  function applyMetrolineStepFilters() {
-    const steps = document.querySelectorAll(".steps .step");
-    const keywordSelect = document.getElementById("keywords-input");
-    const expertiseSelect = document.getElementById("expertise-input");
-    const audienceSelect = document.getElementById("audience-input");
-    const groupSelect = document.getElementById("group-input");
-
-    const selectedKeyword = keywordSelect ? keywordSelect.value : "";
-    const selectedExpertise = expertiseSelect ? expertiseSelect.value : "";
-    const selectedAudience = audienceSelect ? audienceSelect.value : "";
-    const selectedGroup = groupSelect ? groupSelect.value : "";
-    const hasFilterValue = function (values, selectedValue) {
-      return !selectedValue || values.indexOf(`;${selectedValue};`) !== -1;
-    };
-
-    for (const step of steps) {
-      const stepKeywords = step.getAttribute("data-keywords") || "";
-      const stepExpertise = step.getAttribute("data-expertise") || "";
-      const stepAudience = step.getAttribute("data-audience") || "";
-      const stepGroup = step.getAttribute("data-group") || "";
-
-      const keywordMatch = hasFilterValue(stepKeywords, selectedKeyword);
-      const expertiseMatch = hasFilterValue(stepExpertise, selectedExpertise);
-      const audienceMatch = hasFilterValue(stepAudience, selectedAudience);
-      const groupMatch = hasFilterValue(stepGroup, selectedGroup);
-
-      if (keywordMatch && expertiseMatch && audienceMatch && groupMatch) {
-        step.classList.remove("d-none");
-      } else {
-        step.classList.add("d-none");
-      }
-    }
-
-    const params = new URLSearchParams();
-    if (selectedKeyword) params.set("keyword", selectedKeyword);
-    if (selectedExpertise) params.set("expertise", selectedExpertise);
-    if (selectedAudience) params.set("audience", selectedAudience);
-    if (selectedGroup) params.set("group", selectedGroup);
-    const newUrl = params.toString() ? `?${params}` : location.pathname;
-    history.replaceState({}, "", newUrl);
-  }
-
-  $(document).ready(function () {
-    const keywords = document.getElementById("keywords-input");
-    if (keywords) {
-      keywords.addEventListener("change", applyMetrolineStepFilters);
-    }
-
-    const expertise = document.getElementById("expertise-input");
-    if (expertise) {
-      expertise.addEventListener("change", applyMetrolineStepFilters);
-    }
-
-    const audience = document.getElementById("audience-input");
-    if (audience) {
-      audience.addEventListener("change", applyMetrolineStepFilters);
-    }
-
-    const group = document.getElementById("group-input");
-    if (group) {
-      group.addEventListener("change", applyMetrolineStepFilters);
-    }
-
-    const clearKeyword = document.getElementById("clearkeywordfilter");
-    if (clearKeyword) {
-      clearKeyword.addEventListener("click", function () {
-        const keywords = document.getElementById("keywords-input");
-        if (keywords) {
-          keywords.value = "";
-          applyMetrolineStepFilters();
-        }
-      });
-    }
-
-    const clearExpertise = document.getElementById("clearexpertisefilter");
-    if (clearExpertise) {
-      clearExpertise.addEventListener("click", function () {
-        const expertise = document.getElementById("expertise-input");
-        if (expertise) {
-          expertise.value = "";
-          applyMetrolineStepFilters();
-        }
-      });
-    }
-
-    const clearAudience = document.getElementById("clearaudiencefilter");
-    if (clearAudience) {
-      clearAudience.addEventListener("click", function () {
-        const audience = document.getElementById("audience-input");
-        if (audience) {
-          audience.value = "";
-          applyMetrolineStepFilters();
-        }
-      });
-    }
-
-    const clearGroup = document.getElementById("cleargroupfilter");
-    if (clearGroup) {
-      clearGroup.addEventListener("click", function () {
-        const group = document.getElementById("group-input");
-        if (group) {
-          group.value = "";
-          applyMetrolineStepFilters();
-        }
-      });
-    }
-
-    const urlParams = new URLSearchParams(window.location.search);
-    const urlKeyword = urlParams.get("keyword");
-    const urlExpertise = urlParams.get("expertise");
-    const urlAudience = urlParams.get("audience");
-    const urlGroup = urlParams.get("group");
-
-    if (urlKeyword && keywords) {
-      keywords.value = urlKeyword;
-    }
-    if (urlExpertise && expertise) {
-      expertise.value = urlExpertise;
-    }
-    if (urlAudience && audience) {
-      audience.value = urlAudience;
-    }
-    if (urlGroup && group) {
-      group.value = urlGroup;
-    }
-
-    if (urlKeyword || urlExpertise || urlAudience || urlGroup) {
-      applyMetrolineStepFilters();
-    }
-  });
-</script>
+{% include toolassemblies/tile-filters-script.html %}

--- a/pages/fair_metroline_steps.md
+++ b/pages/fair_metroline_steps.md
@@ -2,29 +2,309 @@
 title: FAIR Metroline steps
 ---
 
-## Overview Metroline steps
-<div class="steps">
+{% assign allkeywords = "" %}
+{% assign allexpertise = "" %}
+{% assign allgroups = "" %}
 {% for step in site.data.metroline_steps %}
-  <details class="step">
-    <summary>
-      {{ step.icon }}
-      <strong>{{ step.title }}</strong>
-    </summary>
-    <div class="step-panel">
-      <p>{{ step.summary }}</p>
-      {% if step.url and step.url != blank %}
-        <p><a href="{{ site.baseurl }}/{{ step.url }}">Visit full page ↗</a></p>
-      {% endif %}
+  {% if step.keywords %}
+    {% assign stepkeywords = step.keywords | join: ", " %}
+    {% if allkeywords %}
+      {% assign allkeywords = allkeywords | append: ", " | append: stepkeywords %}
+    {% else %}
+      {% assign allkeywords = allkeywords | append: stepkeywords %}
+    {% endif %}
+  {% endif %}
+  {% if step.expertise_required %}
+    {% assign stepexpertise = step.expertise_required | join: ", " %}
+    {% if allexpertise %}
+      {% assign allexpertise = allexpertise | append: ", " | append: stepexpertise %}
+    {% else %}
+      {% assign allexpertise = allexpertise | append: stepexpertise %}
+    {% endif %}
+  {% endif %}
+  {% if step.group %}
+    {% if allgroups %}
+      {% assign allgroups = allgroups | append: ", " | append: step.group %}
+    {% else %}
+      {% assign allgroups = allgroups | append: step.group %}
+    {% endif %}
+  {% endif %}
+{% endfor %}
+{% assign allkeywords = allkeywords | split: ", " | uniq | sort_natural %}
+{% assign allexpertise = allexpertise | split: ", " | uniq | sort_natural %}
+{% assign allgroups = allgroups | split: ", " | uniq %}
+
+<div class="row g-4 row-cols-1 row-cols-md-2 my-4">
+    <div class="col">
+    <div class="input-group">
+      <label class="input-group-text" for="group-input">Filter by group</label>
+      <select class="form-select" id="group-input" aria-label="Filter by group">
+        <option value="">All groups</option>
+        {% for group in allgroups %}
+          {% if group != "" %}
+            <option value="{{ group | slugify }}">{{ group }}</option>
+          {% endif %}
+        {% endfor %}
+      </select>
+      <button class="btn btn-primary" title="Button to clear group selection" type="button" id="cleargroupfilter">
+        <i class="fa-solid fa-backspace"></i>
+      </button>
     </div>
-  </details>
+  </div>
+  <div class="col">
+    <div class="input-group">
+      <label class="input-group-text" for="keywords-input">Filter by keyword</label>
+      <select class="form-select" id="keywords-input" aria-label="Filter by keyword">
+        <option value="">All keywords</option>
+        {% for keyword in allkeywords %}
+          {% if keyword != "" %}
+            <option value="{{ keyword | slugify }}">{{ keyword }}</option>
+          {% endif %}
+        {% endfor %}
+      </select>
+      <button class="btn btn-primary" title="Button to clear keyword selection" type="button" id="clearkeywordfilter">
+        <i class="fa-solid fa-backspace"></i>
+      </button>
+    </div>
+  </div>
+  <div class="col">
+    <div class="input-group">
+      <label class="input-group-text" for="expertise-input">Filter by expertise</label>
+      <select class="form-select" id="expertise-input" aria-label="Filter by expertise">
+        <option value="">All expertise</option>
+        {% for expertise in allexpertise %}
+          {% if expertise != "" %}
+            <option value="{{ expertise | slugify }}">{{ expertise }}</option>
+          {% endif %}
+        {% endfor %}
+      </select>
+      <button class="btn btn-primary" title="Button to clear expertise selection" type="button" id="clearexpertisefilter">
+        <i class="fa-solid fa-backspace"></i>
+      </button>
+    </div>
+  </div>
+  <div class="col">
+    <div class="input-group">
+      <label class="input-group-text" for="audience-input">Filter by audience</label>
+      <select class="form-select" id="audience-input" aria-label="Filter by audience">
+        <option value="">All audiences</option>
+        <option value="data-holder">Data holder</option>
+        <option value="data-user">Data user</option>
+      </select>
+      <button class="btn btn-primary" title="Button to clear audience selection" type="button" id="clearaudiencefilter">
+        <i class="fa-solid fa-backspace"></i>
+      </button>
+    </div>
+  </div>
+</div>
+
+<div class="steps row row-cols-1 row-cols-md-2 g-4 mb-5 navigation-tiles">
+{% for step in site.data.metroline_steps %}
+  {% capture keyword_classes %}{% for keyword in step.keywords %};{{ keyword | slugify }}{% endfor %};{% endcapture %}
+  {% capture expertise_classes %}{% for expertise in step.expertise_required %};{{ expertise | slugify }}{% endfor %};{% endcapture %}
+  {% capture audience_classes %}{% if step.audience.data_holder %};data-holder{% endif %}{% if step.audience.data_user %};data-user{% endif %};{% endcapture %}
+  <div class="col step" data-keywords="{{ keyword_classes | strip }}" data-expertise="{{ expertise_classes | strip }}" data-audience="{{ audience_classes | strip }}" data-group=";{{ step.group | slugify }};">
+    <a href="{{ site.baseurl }}/{{ step.url }}" class="card h-100 tool-card" aria-label="Go to the {{ step.title }} page">
+      <div class="card-body">
+        <div class="tool-card-icon step-card-icon" aria-hidden="true">
+          <span>{{ step.icon }}</span>
+        </div>
+
+        <h3 class="tool-card-title">{{ step.title }}</h3>
+        <p class="tool-card-description">{{ step.summary }}</p>
+
+        <div class="tool-card-meta">
+          {% if step.keywords %}
+            <div class="tool-tags-group">
+              <span class="tool-tags-label">Keywords:</span>
+              <div class="tool-tags">
+                {% for keyword in step.keywords %}
+                  <span class="badge bg-primary">{{ keyword }}</span>
+                {% endfor %}
+              </div>
+            </div>
+          {% endif %}
+
+          {% if step.expertise_required %}
+            <div class="tool-tags-group">
+              <span class="tool-tags-label">Expertise:</span>
+              <div class="tool-tags">
+                {% for expertise in step.expertise_required %}
+                  <span class="badge bg-secondary">{{ expertise }}</span>
+                {% endfor %}
+              </div>
+            </div>
+          {% endif %}
+
+          {% if step.audience %}
+            <div class="tool-tags-group">
+              <span class="tool-tags-label">Audience:</span>
+              <div class="tool-tags">
+                {% if step.audience.data_holder %}
+                  <span class="badge bg-primary">Data holder</span>
+                {% endif %}
+                {% if step.audience.data_user %}
+                  <span class="badge bg-primary">Data user</span>
+                {% endif %}
+              </div>
+            </div>
+          {% endif %}
+
+          {% if step.group %}
+            <div class="tool-tags-group">
+              <span class="tool-tags-label">Group:</span>
+              <div class="tool-tags">
+                <span class="badge bg-secondary">{{ step.group }}</span>
+              </div>
+            </div>
+          {% endif %}
+        </div>
+      </div>
+    </a>
+  </div>
 {% endfor %}
 </div>
 
 <style>
-  .step { border: 1px solid #e5e7eb; border-radius: .75rem; padding: .5rem .75rem; margin: .5rem 0; }
-  .step > summary { cursor: pointer; list-style: none; }
-  .step > summary::-webkit-details-marker { display: none; }
-  .step > summary::after { content: '▸'; float: right; }
-  .step[open] > summary::after { content: '▾'; }
-  .step-panel { margin-top: .5rem; }
+  .step-card-icon span {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 2.5rem;
+    line-height: 1;
+    min-height: 4rem;
+  }
 </style>
+
+<script type="text/javascript">
+  function applyMetrolineStepFilters() {
+    const steps = document.querySelectorAll(".steps .step");
+    const keywordSelect = document.getElementById("keywords-input");
+    const expertiseSelect = document.getElementById("expertise-input");
+    const audienceSelect = document.getElementById("audience-input");
+    const groupSelect = document.getElementById("group-input");
+
+    const selectedKeyword = keywordSelect ? keywordSelect.value : "";
+    const selectedExpertise = expertiseSelect ? expertiseSelect.value : "";
+    const selectedAudience = audienceSelect ? audienceSelect.value : "";
+    const selectedGroup = groupSelect ? groupSelect.value : "";
+    const hasFilterValue = function (values, selectedValue) {
+      return !selectedValue || values.indexOf(`;${selectedValue};`) !== -1;
+    };
+
+    for (const step of steps) {
+      const stepKeywords = step.getAttribute("data-keywords") || "";
+      const stepExpertise = step.getAttribute("data-expertise") || "";
+      const stepAudience = step.getAttribute("data-audience") || "";
+      const stepGroup = step.getAttribute("data-group") || "";
+
+      const keywordMatch = hasFilterValue(stepKeywords, selectedKeyword);
+      const expertiseMatch = hasFilterValue(stepExpertise, selectedExpertise);
+      const audienceMatch = hasFilterValue(stepAudience, selectedAudience);
+      const groupMatch = hasFilterValue(stepGroup, selectedGroup);
+
+      if (keywordMatch && expertiseMatch && audienceMatch && groupMatch) {
+        step.classList.remove("d-none");
+      } else {
+        step.classList.add("d-none");
+      }
+    }
+
+    const params = new URLSearchParams();
+    if (selectedKeyword) params.set("keyword", selectedKeyword);
+    if (selectedExpertise) params.set("expertise", selectedExpertise);
+    if (selectedAudience) params.set("audience", selectedAudience);
+    if (selectedGroup) params.set("group", selectedGroup);
+    const newUrl = params.toString() ? `?${params}` : location.pathname;
+    history.replaceState({}, "", newUrl);
+  }
+
+  $(document).ready(function () {
+    const keywords = document.getElementById("keywords-input");
+    if (keywords) {
+      keywords.addEventListener("change", applyMetrolineStepFilters);
+    }
+
+    const expertise = document.getElementById("expertise-input");
+    if (expertise) {
+      expertise.addEventListener("change", applyMetrolineStepFilters);
+    }
+
+    const audience = document.getElementById("audience-input");
+    if (audience) {
+      audience.addEventListener("change", applyMetrolineStepFilters);
+    }
+
+    const group = document.getElementById("group-input");
+    if (group) {
+      group.addEventListener("change", applyMetrolineStepFilters);
+    }
+
+    const clearKeyword = document.getElementById("clearkeywordfilter");
+    if (clearKeyword) {
+      clearKeyword.addEventListener("click", function () {
+        const keywords = document.getElementById("keywords-input");
+        if (keywords) {
+          keywords.value = "";
+          applyMetrolineStepFilters();
+        }
+      });
+    }
+
+    const clearExpertise = document.getElementById("clearexpertisefilter");
+    if (clearExpertise) {
+      clearExpertise.addEventListener("click", function () {
+        const expertise = document.getElementById("expertise-input");
+        if (expertise) {
+          expertise.value = "";
+          applyMetrolineStepFilters();
+        }
+      });
+    }
+
+    const clearAudience = document.getElementById("clearaudiencefilter");
+    if (clearAudience) {
+      clearAudience.addEventListener("click", function () {
+        const audience = document.getElementById("audience-input");
+        if (audience) {
+          audience.value = "";
+          applyMetrolineStepFilters();
+        }
+      });
+    }
+
+    const clearGroup = document.getElementById("cleargroupfilter");
+    if (clearGroup) {
+      clearGroup.addEventListener("click", function () {
+        const group = document.getElementById("group-input");
+        if (group) {
+          group.value = "";
+          applyMetrolineStepFilters();
+        }
+      });
+    }
+
+    const urlParams = new URLSearchParams(window.location.search);
+    const urlKeyword = urlParams.get("keyword");
+    const urlExpertise = urlParams.get("expertise");
+    const urlAudience = urlParams.get("audience");
+    const urlGroup = urlParams.get("group");
+
+    if (urlKeyword && keywords) {
+      keywords.value = urlKeyword;
+    }
+    if (urlExpertise && expertise) {
+      expertise.value = urlExpertise;
+    }
+    if (urlAudience && audience) {
+      audience.value = urlAudience;
+    }
+    if (urlGroup && group) {
+      group.value = urlGroup;
+    }
+
+    if (urlKeyword || urlExpertise || urlAudience || urlGroup) {
+      applyMetrolineStepFilters();
+    }
+  });
+</script>


### PR DESCRIPTION
This PR contains:
* First commit
  * Page grouping for the FAIR Metroline pages
    * Instead of a long list with all FAIR Metroline guidance pages, the left-side menu now shows the page groups. Clicking on a group triggers the filtering.
  * Filtering for the FAIR Metroline pages
    * Filtering based on the metadata in the guidance pages as well as the grouping described above
* Second commit
  * Refactoring Guidance + Tooling filtering
    * Since a lot of functionality for the filtering is at its core the same, I asked AI to refactor. After some more optimisation I think this is better
    * I tested whether filtering still works as expected and I think it does. But feel free to try as well!  

If you guys think the refactoring is a bad idea we can go back to the first commit.